### PR TITLE
XD-2357-2391 Initial implementation of Kafka ChannelAdapter using the SimpleConsumer API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ sourceCompatibility = targetCompatibility = 1.6
 
 ext {
 	avroVersion = '1.7.6'
+	gsCollectionsVersion = '5.0.0'
 	jacocoVersion = '0.7.0.201403182114'
 	kafkaVersion = '0.8.1.1'
 	metricsVersion = '2.2.0'
@@ -55,6 +56,7 @@ dependencies {
 	compile "org.springframework.integration:spring-integration-core:$springIntegrationVersion"
 	compile "org.apache.avro:avro:$avroVersion"
 	compile "org.apache.avro:avro-compiler:$avroVersion"
+	compile "com.goldmansachs:gs-collections:$gsCollectionsVersion"
 
 	runtime "com.yammer.metrics:metrics-core:$metricsVersion"
 	runtime "com.yammer.metrics:metrics-annotation:$metricsVersion"
@@ -67,6 +69,7 @@ dependencies {
 
 	testCompile "org.springframework.integration:spring-integration-test:$springIntegrationVersion"
 	testCompile "org.springframework.integration:spring-integration-stream:$springIntegrationVersion"
+	testCompile "org.apache.kafka:kafka_$scalaVersion:$kafkaVersion:test"
 	testCompile "org.slf4j:slf4j-log4j12:1.7.7"
 
 	jacoco "org.jacoco:org.jacoco.agent:$jacocoVersion:runtime"

--- a/src/main/java/org/springframework/integration/kafka/core/KafkaBrokerAddress.java
+++ b/src/main/java/org/springframework/integration/kafka/core/KafkaBrokerAddress.java
@@ -44,14 +44,15 @@ public class KafkaBrokerAddress {
 		this(host, DEFAULT_PORT);
 	}
 
-	public static KafkaBrokerAddress fromAddress(String address)  {
+	public static KafkaBrokerAddress fromAddress(String address) {
 		String[] split = address.split(":");
 		if (split.length == 0 || split.length > 2) {
 			throw new IllegalArgumentException("Expected format <host>[:<port>]");
 		}
 		if (split.length == 2) {
 			return new KafkaBrokerAddress(split[0], Integer.parseInt(split[1]));
-		} else {
+		}
+		else {
 			return new KafkaBrokerAddress(split[0]);
 		}
 
@@ -74,6 +75,11 @@ public class KafkaBrokerAddress {
 	}
 
 	@Override
+	public int hashCode() {
+		return 31 * host.hashCode() + port;
+	}
+
+	@Override
 	public boolean equals(Object o) {
 		if (this == o) {
 			return true;
@@ -92,11 +98,6 @@ public class KafkaBrokerAddress {
 		}
 
 		return true;
-	}
-
-	@Override
-	public int hashCode() {
-		return 31 * host.hashCode() + port;
 	}
 
 	@Override

--- a/src/main/java/org/springframework/integration/kafka/core/KafkaBrokerAddress.java
+++ b/src/main/java/org/springframework/integration/kafka/core/KafkaBrokerAddress.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.springframework.integration.kafka.core;
+
+import org.springframework.util.StringUtils;
+
+/**
+ * Encapsulates the address of a Kafka broker
+ *
+ * @author Marius Bogoevici
+ */
+public class KafkaBrokerAddress {
+
+	public static final int DEFAULT_PORT = 9092;
+
+	private String host;
+
+	private int port;
+
+	public KafkaBrokerAddress(String host, int port) {
+		if (StringUtils.isEmpty(host)) {
+			throw new IllegalArgumentException("Host cannot be empty");
+		}
+		this.host = host;
+		this.port = port;
+	}
+
+	public KafkaBrokerAddress(String host) {
+		this(host, DEFAULT_PORT);
+	}
+
+	public static KafkaBrokerAddress fromAddress(String address)  {
+		String[] split = address.split(":");
+		if (split.length == 0 || split.length > 2) {
+			throw new IllegalArgumentException("Expected format <host>[:<port>]");
+		}
+		if (split.length == 2) {
+			return new KafkaBrokerAddress(split[0], Integer.parseInt(split[1]));
+		} else {
+			return new KafkaBrokerAddress(split[0]);
+		}
+
+	}
+
+	public String getHost() {
+		return host;
+	}
+
+	public void setHost(String host) {
+		this.host = host;
+	}
+
+	public int getPort() {
+		return port;
+	}
+
+	public void setPort(int port) {
+		this.port = port;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+
+		KafkaBrokerAddress kafkaBrokerAddress = (KafkaBrokerAddress) o;
+
+		if (port != kafkaBrokerAddress.port) {
+			return false;
+		}
+		if (!host.equals(kafkaBrokerAddress.host)) {
+			return false;
+		}
+
+		return true;
+	}
+
+	@Override
+	public int hashCode() {
+		return 31 * host.hashCode() + port;
+	}
+
+	@Override
+	public String toString() {
+		return "KafkaBrokerAddress{" +
+				"host='" + host + '\'' +
+				", port=" + port +
+				'}';
+	}
+}
+
+

--- a/src/main/java/org/springframework/integration/kafka/core/KafkaBrokerConnection.java
+++ b/src/main/java/org/springframework/integration/kafka/core/KafkaBrokerConnection.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.springframework.integration.kafka.core;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.gs.collections.api.block.function.Function;
+import com.gs.collections.api.block.function.Function2;
+import com.gs.collections.api.tuple.Pair;
+import com.gs.collections.impl.list.mutable.FastList;
+import com.gs.collections.impl.tuple.Tuples;
+import com.gs.collections.impl.utility.LazyIterate;
+import com.gs.collections.impl.utility.MapIterate;
+import kafka.api.FetchRequestBuilder;
+import kafka.api.PartitionOffsetRequestInfo;
+import kafka.common.ErrorMapping;
+import kafka.common.OffsetMetadataAndError;
+import kafka.common.TopicAndPartition;
+import kafka.javaapi.FetchResponse;
+import kafka.javaapi.OffsetCommitRequest;
+import kafka.javaapi.OffsetCommitResponse;
+import kafka.javaapi.OffsetFetchRequest;
+import kafka.javaapi.OffsetFetchResponse;
+import kafka.javaapi.OffsetRequest;
+import kafka.javaapi.OffsetResponse;
+import kafka.javaapi.PartitionMetadata;
+import kafka.javaapi.TopicMetadata;
+import kafka.javaapi.TopicMetadataRequest;
+import kafka.javaapi.TopicMetadataResponse;
+import kafka.javaapi.consumer.SimpleConsumer;
+import kafka.message.MessageAndOffset;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.util.Assert;
+
+/**
+ * An connection to a Kafka broker - used mainly
+ *
+ * @author Marius Bogoevici
+ */
+public class KafkaBrokerConnection {
+
+	private static Log LOGGER = LogFactory.getLog(KafkaBrokerConnection.class);
+
+	public static final String DEFAULT_CLIENT_ID = "spring.kafka";
+
+	public static final int DEFAULT_BUFFER_SIZE = 64 * 1024;
+
+	public static final int DEFAULT_SOCKET_TIMEOUT = 10 * 1000;
+
+	private final static AtomicInteger CORRELATION_ID_COUNTER = new AtomicInteger(new Random(new Date().getTime()).nextInt());
+
+	private final SimpleConsumer simpleConsumer;
+
+	private KafkaBrokerAddress brokerAddress;
+
+	public KafkaBrokerConnection(KafkaBrokerAddress brokerAddress) {
+		this(brokerAddress, DEFAULT_CLIENT_ID);
+	}
+
+	public KafkaBrokerConnection(KafkaBrokerAddress brokerAddress, String clientId) {
+		this(brokerAddress, clientId,DEFAULT_BUFFER_SIZE,DEFAULT_SOCKET_TIMEOUT);
+	}
+
+	public KafkaBrokerConnection(KafkaBrokerAddress brokerAddress, String clientId, int bufferSize, int soTimeout) {
+		this.brokerAddress = brokerAddress;
+		this.simpleConsumer = new SimpleConsumer(brokerAddress.getHost(), brokerAddress.getPort(), soTimeout, bufferSize, clientId);
+	}
+
+	/**
+	 * The broker address for this consumer
+	 *
+	 * @return
+	 */
+	public KafkaBrokerAddress getBrokerAddress() {
+		return brokerAddress;
+	}
+
+	public void close() {
+		this.simpleConsumer.close();
+	}
+
+	/**
+	 * Fetches results
+	 *
+	 * @return a combination of messages and errors, depending on whether the invocation was successful or not
+	 */
+	public KafkaResult<KafkaMessageBatch> fetch(KafkaMessageFetchRequest... requests) {
+		FetchRequestBuilder fetchRequestBuilder = new FetchRequestBuilder();
+		for (KafkaMessageFetchRequest kafkaMessageFetchRequest : requests) {
+			fetchRequestBuilder.addFetch(kafkaMessageFetchRequest.getPartition().getTopic(), kafkaMessageFetchRequest.getPartition().getId(), kafkaMessageFetchRequest.getOffset(), kafkaMessageFetchRequest.getMaxSize());
+		}
+		FetchResponse fetchResponse = this.simpleConsumer.fetch(fetchRequestBuilder.build());
+		KafkaResultBuilder<KafkaMessageBatch> kafkaResultBuilder = new KafkaResultBuilder<KafkaMessageBatch>();
+		for (final KafkaMessageFetchRequest kafkaMessageFetchRequest : requests) {
+			if (LOGGER.isDebugEnabled()) {
+				LOGGER.debug("Reading from " + kafkaMessageFetchRequest.getPartition() + "@" + kafkaMessageFetchRequest.getOffset());
+			}
+			short errorCode = fetchResponse.errorCode(kafkaMessageFetchRequest.getPartition().getTopic(), kafkaMessageFetchRequest.getPartition().getId());
+			if (ErrorMapping.NoError() == errorCode) {
+				List<KafkaMessage> kafkaMessages = LazyIterate.collect(fetchResponse.messageSet(kafkaMessageFetchRequest.getPartition().getTopic(), kafkaMessageFetchRequest.getPartition().getId()), new Function<MessageAndOffset, KafkaMessage>() {
+					@Override
+					public KafkaMessage valueOf(MessageAndOffset messageAndOffset) {
+						return new KafkaMessage(messageAndOffset.message(), new KafkaMessageMetadata(kafkaMessageFetchRequest.getPartition(),messageAndOffset.offset(), messageAndOffset.nextOffset()));
+					}
+				}).toList();
+				kafkaResultBuilder.add(kafkaMessageFetchRequest.getPartition()).withResult(new KafkaMessageBatch(kafkaMessageFetchRequest.getPartition(), kafkaMessages,fetchResponse.highWatermark(kafkaMessageFetchRequest.getPartition().getTopic(), kafkaMessageFetchRequest.getPartition().getId())));
+			}
+			else {
+				kafkaResultBuilder.add(kafkaMessageFetchRequest.getPartition()).withError(fetchResponse.errorCode(kafkaMessageFetchRequest.getPartition().getTopic(), kafkaMessageFetchRequest.getPartition().getId()));
+			}
+		}
+		return kafkaResultBuilder.build();
+	}
+
+	public KafkaResult<Long> fetchStoredOffsetsForConsumer(String consumerId, Partition... partitions) {
+		FastList<TopicAndPartition> topicsAndPartitions = FastList.newList(Arrays.asList(partitions)).collect(new Function<Partition, TopicAndPartition>() {
+			@Override
+			public TopicAndPartition valueOf(Partition partition) {
+				return new TopicAndPartition(partition.getTopic(), partition.getId());
+			}
+		});
+		OffsetFetchRequest offsetFetchRequest = new OffsetFetchRequest(consumerId, topicsAndPartitions, kafka.api.OffsetFetchRequest.CurrentVersion(), createCorrelationId(), simpleConsumer.clientId());
+		OffsetFetchResponse offsetFetchResponse = simpleConsumer.fetchOffsets(offsetFetchRequest);
+		KafkaResultBuilder<Long> kafkaResultBuilder = new KafkaResultBuilder<Long>();
+		for (Partition partition : partitions) {
+			OffsetMetadataAndError offsetMetadataAndError = offsetFetchResponse.offsets().get(partition);
+			short errorCode = offsetMetadataAndError.error();
+			if (ErrorMapping.NoError() == errorCode) {
+				kafkaResultBuilder.add(partition).withResult(offsetMetadataAndError.offset());
+			}
+			else {
+				kafkaResultBuilder.add(partition).withError(offsetMetadataAndError.error());
+			}
+		}
+		return kafkaResultBuilder.build();
+	}
+
+	public KafkaResult<Long> fetchInitialOffset(long referenceTime, Partition... topicsAndPartitions) {
+		Assert.isTrue(topicsAndPartitions.length > 0, "Must provide at least one partition");
+		Map<TopicAndPartition, PartitionOffsetRequestInfo> infoMap = new HashMap<TopicAndPartition, PartitionOffsetRequestInfo>();
+		for (Partition partition: topicsAndPartitions) {
+			infoMap.put(new TopicAndPartition(partition.getTopic(), partition.getId()), new PartitionOffsetRequestInfo(referenceTime, 1));
+		}
+		OffsetRequest offsetRequest = new OffsetRequest(infoMap, kafka.api.OffsetRequest.CurrentVersion(), simpleConsumer.clientId());
+		OffsetResponse offsetResponse = simpleConsumer.getOffsetsBefore(offsetRequest);
+		KafkaResultBuilder<Long> kafkaResultBuilder = new KafkaResultBuilder<Long>();
+		for (Partition partition : topicsAndPartitions) {
+			short errorCode = offsetResponse.errorCode(partition.getTopic(), partition.getId());
+			if (ErrorMapping.NoError() == errorCode) {
+				long[] offsets = offsetResponse.offsets(partition.getTopic(), partition.getId());
+				if (offsets.length == 0) {
+					throw new IllegalStateException("No error has been returned, but no offsets either");
+				}
+				kafkaResultBuilder.add(partition).withResult(offsets[0]);
+			}
+			else {
+				kafkaResultBuilder.add(partition).withError(errorCode);
+			}
+		}
+		return kafkaResultBuilder.build();
+	}
+
+	public KafkaResult<Void> commitOffsetsForConsumer(String consumerId, Map<Partition, Long> offsets) {
+		Map<TopicAndPartition, OffsetMetadataAndError> requestInfo = MapIterate.collect(offsets, new Function2<Partition, Long, Pair<TopicAndPartition, OffsetMetadataAndError>>() {
+			@Override
+			public Pair<TopicAndPartition, OffsetMetadataAndError> value(Partition partition, Long offset) {
+				return Tuples.pair(
+						new TopicAndPartition(partition.getTopic(),
+						partition.getId()),new OffsetMetadataAndError(offset, OffsetMetadataAndError.NoMetadata(), ErrorMapping.NoError()));
+			}
+		});
+		OffsetCommitResponse offsetCommitResponse = simpleConsumer.commitOffsets(
+				new OffsetCommitRequest(consumerId, requestInfo, kafka.api.OffsetCommitRequest.CurrentVersion(), createCorrelationId(), simpleConsumer.clientId()));
+		KafkaResultBuilder<Void> kafkaResultBuilder = new KafkaResultBuilder<Void>();
+		for (TopicAndPartition topicAndPartition : requestInfo.keySet()) {
+			if (offsetCommitResponse.errors().containsKey(topicAndPartition)) {
+				kafkaResultBuilder.add(new Partition(topicAndPartition.topic(), topicAndPartition.partition())).withError((Short) offsetCommitResponse.errors().get(topicAndPartition));
+			}
+		}
+		return kafkaResultBuilder.build();
+	}
+
+	public KafkaResult<KafkaBrokerAddress> findLeaders(String... topics) {
+		TopicMetadataRequest topicMetadataRequest = new TopicMetadataRequest(Arrays.asList(topics), createCorrelationId());
+		TopicMetadataResponse topicMetadataResponse = simpleConsumer.send(topicMetadataRequest);
+		KafkaResultBuilder<KafkaBrokerAddress> kafkaResultBuilder = new KafkaResultBuilder<KafkaBrokerAddress>();
+		for (TopicMetadata topicMetadata : topicMetadataResponse.topicsMetadata()) {
+			if (topicMetadata.errorCode() != ErrorMapping.NoError()) {
+				kafkaResultBuilder.add(new Partition(topicMetadata.topic(), -1)).withError(topicMetadata.errorCode());
+			}
+			else {
+				for (PartitionMetadata partitionMetadata : topicMetadata.partitionsMetadata()) {
+					if (ErrorMapping.NoError() == partitionMetadata.errorCode()) {
+						kafkaResultBuilder.add(new Partition(topicMetadata.topic(), partitionMetadata.partitionId())).withResult(new KafkaBrokerAddress(partitionMetadata.leader().host(), partitionMetadata.leader().port()));
+					} else {
+						kafkaResultBuilder.add(new Partition(topicMetadata.topic(), partitionMetadata.partitionId())).withError(partitionMetadata.errorCode());
+					}
+				}
+
+			}
+		}
+		return kafkaResultBuilder.build();
+	}
+
+	/**
+	 * Creates a pseudo-unique correlation id for requests and responses
+	 *
+	 * @return correlation id
+	 */
+	private static Integer createCorrelationId() {
+		return CORRELATION_ID_COUNTER.incrementAndGet();
+	}
+
+}

--- a/src/main/java/org/springframework/integration/kafka/core/KafkaBrokerConnectionFactory.java
+++ b/src/main/java/org/springframework/integration/kafka/core/KafkaBrokerConnectionFactory.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.springframework.integration.kafka.core;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.gs.collections.api.block.function.Function;
+import com.gs.collections.impl.block.factory.Functions;
+import com.gs.collections.impl.list.mutable.FastList;
+import com.gs.collections.impl.map.mutable.UnifiedMap;
+
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.util.Assert;
+
+/**
+ * Creates Kafka connections and retrieves metadata for topics and partitions
+ *
+ * @author Marius Bogoevici
+ */
+public class KafkaBrokerConnectionFactory implements InitializingBean {
+
+	private final KafkaConfiguration kafkaConfiguration;
+
+	private UnifiedMap<KafkaBrokerAddress, KafkaBrokerConnection> kafkaBrokersCache = UnifiedMap.newMap();
+
+	private final AtomicReference<PartitionBrokerMap> partitionBrokerMapReference = new AtomicReference<PartitionBrokerMap>();
+
+	private KafkaBrokerConnection defaultConnection;
+
+	public KafkaBrokerConnectionFactory(KafkaConfiguration kafkaConfiguration) {
+		this.kafkaConfiguration = kafkaConfiguration;
+	}
+
+	public List<KafkaBrokerAddress> getBrokerAddresses() {
+		return kafkaConfiguration.getBrokerAddresses();
+	}
+
+	public KafkaConfiguration getKafkaConfiguration() {
+		return kafkaConfiguration;
+	}
+
+	@Override
+	public void afterPropertiesSet() throws Exception {
+		Assert.notNull(this.kafkaConfiguration, "Kafka configuration cannot be empty");
+		this.refreshLeaders();
+	}
+
+
+	/**
+	 * Retrieves the leaders for a set of partitions.
+	 *
+	 * @param partitions
+	 * @return the broker associated with the provided topic and partition
+	 */
+	public Map<Partition, KafkaBrokerAddress> getLeaders(Partition... partitions) {
+		return FastList.newListWith(partitions).toMap(Functions.<Partition>getPassThru(), new Function<Partition, KafkaBrokerAddress>() {
+			@Override
+			public KafkaBrokerAddress valueOf(Partition partition) {
+				return KafkaBrokerConnectionFactory.this.partitionBrokerMapReference.get().getBrokersByPartition().get(partition);
+			}
+		});
+	}
+
+	/**
+	 * Returns the leader for a single partition
+	 *
+	 * @param partition
+	 * @return
+	 */
+	public KafkaBrokerAddress getLeader(Partition partition) {
+		return this.getLeaders(partition).get(partition);
+	}
+
+	/**
+	 * Returns the partitions of which the given broker is the leader
+	 *
+	 * @param kafkaBrokerAddress
+	 * @return
+	 */
+	public List<Partition> getPartitions(KafkaBrokerAddress kafkaBrokerAddress) {
+		return this.partitionBrokerMapReference.get().getPartitionsByBroker().get(kafkaBrokerAddress).toList();
+	}
+
+	/**
+	 * Creates a connection to a Kafka broker, caching it internally
+	 *
+	 * @param kafkaBrokerAddress
+	 * @return
+	 */
+	public KafkaBrokerConnection createConnection(KafkaBrokerAddress kafkaBrokerAddress) {
+		return kafkaBrokersCache.getIfAbsentPutWith(kafkaBrokerAddress, new KafkaBrokerConnectionInstantiator(), kafkaBrokerAddress);
+	}
+
+	/**
+	 * Refreshes the broker connections and partition leader internal. To be called when the topology changes (i.e. brokers leave and/or partition leaders change)
+	 */
+	public void refreshLeaders() {
+		synchronized (partitionBrokerMapReference) {
+			for (KafkaBrokerConnection kafkaBrokerConnection : kafkaBrokersCache) {
+				kafkaBrokerConnection.close();
+			}
+			Iterator<KafkaBrokerAddress> kafkaBrokerAddressIterator = kafkaConfiguration.getBrokerAddresses().iterator();
+			do {
+				KafkaBrokerConnection candidateConnection = this.createConnection(kafkaBrokerAddressIterator.next());
+				KafkaResult<KafkaBrokerAddress> leaders = candidateConnection.findLeaders();
+				if (leaders.getErrors().size() == 0) {
+					this.defaultConnection = candidateConnection;
+					this.partitionBrokerMapReference.set(new PartitionBrokerMap(UnifiedMap.newMap(leaders.getResults())));
+				}
+			} while (kafkaBrokerAddressIterator.hasNext() && this.defaultConnection == null);
+		}
+	}
+
+	public Collection<Partition> getPartitions() {
+		return getPartitionBrokerMap().getBrokersByPartition().keysView().toSet();
+	}
+
+	public Collection<Partition> getPartitions(String topic) {
+		return getPartitionBrokerMap().getPartitionsByTopic().get(topic).toList();
+	}
+
+	private class KafkaBrokerConnectionInstantiator implements Function<KafkaBrokerAddress, KafkaBrokerConnection> {
+		@Override
+		public KafkaBrokerConnection valueOf(KafkaBrokerAddress kafkaBrokerAddress) {
+			KafkaBrokerConnectionFactory kafkaBrokerConnectionFactory = KafkaBrokerConnectionFactory.this;
+			if (kafkaBrokerConnectionFactory.defaultConnection != null
+					&& kafkaBrokerConnectionFactory.defaultConnection.getBrokerAddress().equals(kafkaBrokerAddress)) {
+				return KafkaBrokerConnectionFactory.this.defaultConnection;
+			}
+			else {
+				return new KafkaBrokerConnection(kafkaBrokerAddress);
+			}
+		}
+	}
+
+	private PartitionBrokerMap getPartitionBrokerMap() {
+		return partitionBrokerMapReference.get();
+	}
+
+}

--- a/src/main/java/org/springframework/integration/kafka/core/KafkaConfiguration.java
+++ b/src/main/java/org/springframework/integration/kafka/core/KafkaConfiguration.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.springframework.integration.kafka.core;
+
+import java.util.List;
+
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+
+/**
+ * Provides a starting configuration for
+ * @author Marius Bogoevici
+ */
+public class KafkaConfiguration implements InitializingBean {
+
+	private List<KafkaBrokerAddress> brokerAddresses;
+
+	private List<Partition> defaultPartitions;
+
+	private String defaultTopic;
+
+	public KafkaConfiguration(List<KafkaBrokerAddress> brokerAddresses) {
+		this.brokerAddresses = brokerAddresses;
+	}
+
+	@Override
+	public void afterPropertiesSet() throws Exception {
+		Assert.isTrue(CollectionUtils.isEmpty(defaultPartitions) || StringUtils.isEmpty(defaultTopic), "A list of default partitions or a default topic may be specified, but not both");
+	}
+
+	public List<KafkaBrokerAddress> getBrokerAddresses() {
+		return brokerAddresses;
+	}
+
+	public void setBrokerAddresses(List<KafkaBrokerAddress> brokerAddresses) {
+		this.brokerAddresses = brokerAddresses;
+	}
+
+	public void setDefaultPartitions(List<Partition> defaultPartitions) {
+		this.defaultPartitions = defaultPartitions;
+	}
+
+	public List<Partition> getDefaultPartitions() {
+		return defaultPartitions;
+	}
+
+	public String getDefaultTopic() {
+		return defaultTopic;
+	}
+
+	public void setDefaultTopic(String defaultTopic) {
+		this.defaultTopic = defaultTopic;
+	}
+}

--- a/src/main/java/org/springframework/integration/kafka/core/KafkaConfiguration.java
+++ b/src/main/java/org/springframework/integration/kafka/core/KafkaConfiguration.java
@@ -26,6 +26,7 @@ import org.springframework.util.StringUtils;
 
 /**
  * Provides a starting configuration for
+ *
  * @author Marius Bogoevici
  */
 public class KafkaConfiguration implements InitializingBean {
@@ -42,7 +43,8 @@ public class KafkaConfiguration implements InitializingBean {
 
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		Assert.isTrue(CollectionUtils.isEmpty(defaultPartitions) || StringUtils.isEmpty(defaultTopic), "A list of default partitions or a default topic may be specified, but not both");
+		Assert.isTrue(CollectionUtils.isEmpty(defaultPartitions) || StringUtils.isEmpty(defaultTopic)
+				, "A list of default partitions or a default topic may be specified, but not both");
 	}
 
 	public List<KafkaBrokerAddress> getBrokerAddresses() {
@@ -53,12 +55,12 @@ public class KafkaConfiguration implements InitializingBean {
 		this.brokerAddresses = brokerAddresses;
 	}
 
-	public void setDefaultPartitions(List<Partition> defaultPartitions) {
-		this.defaultPartitions = defaultPartitions;
-	}
-
 	public List<Partition> getDefaultPartitions() {
 		return defaultPartitions;
+	}
+
+	public void setDefaultPartitions(List<Partition> defaultPartitions) {
+		this.defaultPartitions = defaultPartitions;
 	}
 
 	public String getDefaultTopic() {

--- a/src/main/java/org/springframework/integration/kafka/core/KafkaMessage.java
+++ b/src/main/java/org/springframework/integration/kafka/core/KafkaMessage.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.springframework.integration.kafka.core;
+
+import kafka.message.Message;
+
+/**
+ * Wrapper around a {@link KafkaMessage}, grouping the original {@link Message} content and metadata.
+ *
+ * @author Marius Bogoevici
+ */
+public class KafkaMessage {
+
+	private final Message message;
+
+	private final KafkaMessageMetadata metadata;
+
+	public KafkaMessage(Message message, KafkaMessageMetadata metadata) {
+		this.message = message;
+		this.metadata = metadata;
+	}
+
+	public Message getMessage() {
+		return message;
+	}
+
+	public KafkaMessageMetadata getMetadata() {
+		return metadata;
+	}
+
+}

--- a/src/main/java/org/springframework/integration/kafka/core/KafkaMessageBatch.java
+++ b/src/main/java/org/springframework/integration/kafka/core/KafkaMessageBatch.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.springframework.integration.kafka.core;
+
+import java.util.List;
+
+/**
+ * @author Marius Bogoevici
+ */
+public class KafkaMessageBatch {
+
+	private Partition partition;
+
+	private List<KafkaMessage> messages;
+
+	private long highWatermark;
+
+	public KafkaMessageBatch(Partition partition, List<KafkaMessage> messages, long highWatermark) {
+		this.partition = partition;
+		this.messages = messages;
+		this.highWatermark = highWatermark;
+	}
+
+	public Partition getPartition() {
+		return partition;
+	}
+
+	public void setPartition(Partition partition) {
+		this.partition = partition;
+	}
+
+	public List<KafkaMessage> getMessages() {
+		return messages;
+	}
+
+	public void setMessages(List<KafkaMessage> messages) {
+		this.messages = messages;
+	}
+
+	public long getHighWatermark() {
+		return highWatermark;
+	}
+
+	public void setHighWatermark(long highWatermark) {
+		this.highWatermark = highWatermark;
+	}
+}

--- a/src/main/java/org/springframework/integration/kafka/core/KafkaMessageFetchRequest.java
+++ b/src/main/java/org/springframework/integration/kafka/core/KafkaMessageFetchRequest.java
@@ -17,8 +17,6 @@
 
 package org.springframework.integration.kafka.core;
 
-import org.springframework.integration.kafka.core.Partition;
-
 /**
  * Encapsulates a request for fetching messages from the server.
  *

--- a/src/main/java/org/springframework/integration/kafka/core/KafkaMessageFetchRequest.java
+++ b/src/main/java/org/springframework/integration/kafka/core/KafkaMessageFetchRequest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.springframework.integration.kafka.core;
+
+import org.springframework.integration.kafka.core.Partition;
+
+/**
+ * Encapsulates a request for fetching messages from the server.
+ *
+ * @author Marius Bogoevici
+ */
+public class KafkaMessageFetchRequest {
+
+	private Partition partition;
+
+	private long offset;
+
+	private int maxSize;
+
+	public KafkaMessageFetchRequest(Partition Partition, long offset, int maxSize) {
+		this.partition = Partition;
+		this.offset = offset;
+		this.maxSize = maxSize;
+	}
+
+	public Partition getPartition() {
+		return partition;
+	}
+
+	public void setPartition(Partition partition) {
+		this.partition = partition;
+	}
+
+	public long getOffset() {
+		return offset;
+	}
+
+	public void setOffset(long offset) {
+		this.offset = offset;
+	}
+
+	public int getMaxSize() {
+		return maxSize;
+	}
+
+	public void setMaxSize(int maxSize) {
+		this.maxSize = maxSize;
+	}
+}

--- a/src/main/java/org/springframework/integration/kafka/core/KafkaMessageMetadata.java
+++ b/src/main/java/org/springframework/integration/kafka/core/KafkaMessageMetadata.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.springframework.integration.kafka.core;
+
+import kafka.message.Message;
+
+import org.springframework.integration.kafka.core.Partition;
+
+/**
+ * Metadata for a Kafka {@link Message}.
+ *
+ * @author Marius Bogoevici
+ */
+public class KafkaMessageMetadata {
+
+	private long offset;
+
+	private long nextOffset;
+
+	private Partition partition;
+
+	public KafkaMessageMetadata(Partition partition, long offset, long nextOffset) {
+		this.offset = offset;
+		this.nextOffset = nextOffset;
+		this.partition = partition;
+	}
+
+	public Partition getPartition() {
+		return partition;
+	}
+
+	public void setPartition(Partition partition) {
+		this.partition = partition;
+	}
+
+	public long getOffset() {
+		return offset;
+	}
+
+	public void setOffset(long offset) {
+		this.offset = offset;
+	}
+
+	public long getNextOffset() {
+		return nextOffset;
+	}
+
+	public void setNextOffset(long nextOffset) {
+		this.nextOffset = nextOffset;
+	}
+
+}

--- a/src/main/java/org/springframework/integration/kafka/core/KafkaMessageMetadata.java
+++ b/src/main/java/org/springframework/integration/kafka/core/KafkaMessageMetadata.java
@@ -19,8 +19,6 @@ package org.springframework.integration.kafka.core;
 
 import kafka.message.Message;
 
-import org.springframework.integration.kafka.core.Partition;
-
 /**
  * Metadata for a Kafka {@link Message}.
  *

--- a/src/main/java/org/springframework/integration/kafka/core/KafkaResult.java
+++ b/src/main/java/org/springframework/integration/kafka/core/KafkaResult.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.springframework.integration.kafka.core;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * The result of a Kafka SimpleConsumer operation
+ *
+ * @author Marius Bogoevici
+ */
+public class KafkaResult<T> {
+
+	private Map<Partition, T> results;
+
+	private Map<Partition, Short> errors;
+
+	KafkaResult(Map<Partition, T> results, Map<Partition, Short> errors) {
+		this.results = Collections.unmodifiableMap(results);
+		this.errors = Collections.unmodifiableMap(errors);
+	}
+
+	public Map<Partition, T> getResults() {
+		return results;
+	}
+
+	public T getResult(Partition partition) throws IllegalArgumentException {
+		if (this.results.containsKey(partition)) {
+			return this.results.get(partition);
+		}
+		else {
+			throw new IllegalArgumentException(" No result received for " + partition.toString());
+		}
+	}
+
+	public Map<Partition, Short> getErrors() {
+		return errors;
+	}
+
+	/**
+	 * Returns the error reported as a result of a Kafka SimpleConsumer API call, if any.
+	 *
+	 * @param partition
+	 * @return
+	 */
+	public short getError(Partition partition) throws IllegalArgumentException {
+		if (this.getErrors().containsKey(partition)) {
+			return this.getErrors().get(partition);
+		}
+		else {
+			throw new IllegalArgumentException("No error received for " + partition.toString());
+		}
+	}
+
+}

--- a/src/main/java/org/springframework/integration/kafka/core/KafkaResultBuilder.java
+++ b/src/main/java/org/springframework/integration/kafka/core/KafkaResultBuilder.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.springframework.integration.kafka.core;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Utility class for building a {@link KafkaResult}
+ *
+ * @author Marius Bogoevici
+ */
+class KafkaResultBuilder<T> {
+
+	private Map<Partition, T> result;
+
+	private Map<Partition, Short> errors;
+
+	public KafkaResultBuilder() {
+		this.result = new HashMap<Partition, T>();
+		this.errors = new HashMap<Partition, Short>();
+	}
+
+	public KafkaPartitionResultHolder add(Partition Partition) {
+		return new KafkaPartitionResultHolder(Partition);
+	}
+
+	public KafkaResult<T> build() {
+		return new KafkaResult<T>(result, errors);
+	}
+
+	class KafkaPartitionResultHolder {
+
+		private Partition Partition;
+
+		public KafkaPartitionResultHolder(Partition Partition) {
+			this.Partition = Partition;
+		}
+
+		public KafkaResultBuilder withResult(T result) {
+			if (KafkaResultBuilder.this.errors.containsKey(Partition)) {
+				throw new IllegalArgumentException("A KafkaResult cannot contain both an error and a result for the same topic and partition");
+			}
+			KafkaResultBuilder.this.result.put(Partition, result);
+			return KafkaResultBuilder.this;
+		}
+
+		public KafkaResultBuilder withError(short error) {
+			if (KafkaResultBuilder.this.result.containsKey(Partition)) {
+				throw new IllegalArgumentException("A FetchResult cannot contain both an error and a MessageSet for the same topic and partition");
+			}
+			KafkaResultBuilder.this.errors.put(Partition, error);
+			return KafkaResultBuilder.this;
+		}
+
+	}
+}

--- a/src/main/java/org/springframework/integration/kafka/core/KafkaTemplate.java
+++ b/src/main/java/org/springframework/integration/kafka/core/KafkaTemplate.java
@@ -26,13 +26,6 @@ import com.gs.collections.api.list.MutableList;
 import com.gs.collections.impl.list.mutable.FastList;
 import com.gs.collections.impl.utility.ArrayIterate;
 
-import org.springframework.integration.kafka.core.KafkaBrokerAddress;
-import org.springframework.integration.kafka.core.KafkaBrokerConnectionFactory;
-import org.springframework.integration.kafka.core.KafkaResult;
-import org.springframework.integration.kafka.core.Partition;
-import org.springframework.integration.kafka.core.KafkaMessageBatch;
-import org.springframework.integration.kafka.core.KafkaMessageFetchRequest;
-
 
 /**
  * A Template for executing high-level operations on a set of Kafka brokers.

--- a/src/main/java/org/springframework/integration/kafka/core/KafkaTemplate.java
+++ b/src/main/java/org/springframework/integration/kafka/core/KafkaTemplate.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.springframework.integration.kafka.core;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import com.gs.collections.api.block.function.Function;
+import com.gs.collections.api.list.MutableList;
+import com.gs.collections.impl.list.mutable.FastList;
+import com.gs.collections.impl.utility.ArrayIterate;
+
+import org.springframework.integration.kafka.core.KafkaBrokerAddress;
+import org.springframework.integration.kafka.core.KafkaBrokerConnectionFactory;
+import org.springframework.integration.kafka.core.KafkaResult;
+import org.springframework.integration.kafka.core.Partition;
+import org.springframework.integration.kafka.core.KafkaMessageBatch;
+import org.springframework.integration.kafka.core.KafkaMessageFetchRequest;
+
+
+/**
+ * A Template for executing high-level operations on a set of Kafka brokers.
+ *
+ * @author Marius Bogoevici
+ */
+public class KafkaTemplate {
+
+	private final KafkaBrokerConnectionFactory kafkaBrokerConnectionFactory;
+
+	public KafkaTemplate(KafkaBrokerConnectionFactory kafkaBrokerConnectionFactory) {
+		this.kafkaBrokerConnectionFactory = kafkaBrokerConnectionFactory;
+	}
+
+	public KafkaBrokerConnectionFactory getKafkaBrokerConnectionFactory() {
+		return kafkaBrokerConnectionFactory;
+	}
+
+	public List<KafkaMessageBatch> receive(KafkaBrokerAddress kafkaBrokerAddress, final Map<Partition, Long> offsets, final int maxSize) {
+		return this.receive(FastList.newList(kafkaBrokerConnectionFactory.getPartitions(kafkaBrokerAddress)).collect(new Function<Partition, KafkaMessageFetchRequest>() {
+			@Override
+			public KafkaMessageFetchRequest valueOf(Partition partition) {
+				return new KafkaMessageFetchRequest(partition, offsets.get(partition), maxSize);
+			}
+		}).toTypedArray(KafkaMessageFetchRequest.class));
+	}
+
+	public List<KafkaMessageBatch> receive(KafkaMessageFetchRequest... messageFetchRequests) {
+		MutableList<KafkaBrokerAddress> distinctBrokerAddresses = ArrayIterate.collect(messageFetchRequests, new Function<KafkaMessageFetchRequest, KafkaBrokerAddress>() {
+			@Override
+			public KafkaBrokerAddress valueOf(KafkaMessageFetchRequest fetchRequest) {
+				return kafkaBrokerConnectionFactory.getLeader(fetchRequest.getPartition());
+			}
+		}).distinct();
+		if (distinctBrokerAddresses.size() != 1) {
+			throw new IllegalArgumentException("All messages must be fetched from the same broker");
+		}
+		KafkaResult<KafkaMessageBatch> fetch = kafkaBrokerConnectionFactory.createConnection(distinctBrokerAddresses.get(0)).fetch(messageFetchRequests);
+		if (fetch.getErrors().size() > 0) {
+			// synchronously refresh on error
+			kafkaBrokerConnectionFactory.refreshLeaders();
+		}
+		return new ArrayList<KafkaMessageBatch>(fetch.getResults().values());
+	}
+
+}

--- a/src/main/java/org/springframework/integration/kafka/core/Partition.java
+++ b/src/main/java/org/springframework/integration/kafka/core/Partition.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.springframework.integration.kafka.core;
+
+/**
+ * A reference to a Kafka partition, with both String and partition id
+ *
+ * @author Marius Bogoevici
+ */
+public class Partition {
+
+	private String topic;
+
+	private int id;
+
+	public Partition(String topic, int id) {
+		this.topic = topic;
+		this.id = id;
+	}
+
+	public String getTopic() {
+		return topic;
+	}
+
+	public void setTopic(String topic) {
+		this.topic = topic;
+	}
+
+	public int getId() {
+		return id;
+	}
+
+	public void setId(int id) {
+		this.id = id;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		Partition partition = (Partition) o;
+		if (id != partition.id) {
+			return false;
+		}
+		if (!topic.equals(partition.topic)) {
+			return false;
+		}
+		return true;
+	}
+
+	@Override
+	public int hashCode() {
+		int result = topic.hashCode();
+		result = 31 * result + id;
+		return result;
+	}
+
+	@Override
+	public String toString() {
+		return "Partition[" + "topic='" + topic + '\'' + ", id=" + id + ']';
+	}
+}

--- a/src/main/java/org/springframework/integration/kafka/core/Partition.java
+++ b/src/main/java/org/springframework/integration/kafka/core/Partition.java
@@ -50,6 +50,13 @@ public class Partition {
 	}
 
 	@Override
+	public int hashCode() {
+		int result = topic.hashCode();
+		result = 31 * result + id;
+		return result;
+	}
+
+	@Override
 	public boolean equals(Object o) {
 		if (this == o) {
 			return true;
@@ -65,13 +72,6 @@ public class Partition {
 			return false;
 		}
 		return true;
-	}
-
-	@Override
-	public int hashCode() {
-		int result = topic.hashCode();
-		result = 31 * result + id;
-		return result;
 	}
 
 	@Override

--- a/src/main/java/org/springframework/integration/kafka/core/PartitionBrokerMap.java
+++ b/src/main/java/org/springframework/integration/kafka/core/PartitionBrokerMap.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.springframework.integration.kafka.core;
+
+import com.gs.collections.api.block.function.Function;
+import com.gs.collections.api.map.ImmutableMap;
+import com.gs.collections.api.multimap.Multimap;
+import com.gs.collections.impl.map.mutable.UnifiedMap;
+
+/**
+ * Immutable store for the partition/broker mapping
+ *
+ * @author Marius Bogoevici
+ */
+class PartitionBrokerMap {
+
+	private Multimap<KafkaBrokerAddress, Partition> partitionsByBroker;
+
+	private ImmutableMap<Partition, KafkaBrokerAddress> brokersByPartition;
+
+	private Multimap<String, Partition> partitionsByTopic;
+
+	public PartitionBrokerMap(UnifiedMap<Partition, KafkaBrokerAddress> brokersByPartition) {
+		this.brokersByPartition = brokersByPartition.toImmutable();
+		this.partitionsByTopic = this.brokersByPartition.keysView().groupBy(new Function<Partition, String>() {
+			@Override
+			public String valueOf(Partition partition) {
+				return partition.getTopic();
+			}
+		});
+		this.partitionsByBroker = brokersByPartition.flip().toImmutable();
+	}
+
+	public Multimap<KafkaBrokerAddress, Partition> getPartitionsByBroker() {
+		return partitionsByBroker;
+	}
+
+	public ImmutableMap<Partition, KafkaBrokerAddress> getBrokersByPartition() {
+		return brokersByPartition;
+	}
+
+	public Multimap<String, Partition> getPartitionsByTopic() {
+		return partitionsByTopic;
+	}
+}

--- a/src/main/java/org/springframework/integration/kafka/inbound/KafkaInboundChannelAdapter.java
+++ b/src/main/java/org/springframework/integration/kafka/inbound/KafkaInboundChannelAdapter.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.springframework.integration.kafka.inbound;
+
+import kafka.serializer.Decoder;
+import kafka.serializer.DefaultDecoder;
+
+import org.springframework.integration.context.OrderlyShutdownCapable;
+import org.springframework.integration.endpoint.MessageProducerSupport;
+import org.springframework.integration.kafka.core.KafkaMessageMetadata;
+import org.springframework.integration.kafka.listener.AbstractDecodingMessageListener;
+import org.springframework.integration.kafka.listener.KafkaMessageListenerContainer;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.util.Assert;
+
+/**
+ * @author Marius Bogoevici
+ */
+public class KafkaInboundChannelAdapter extends MessageProducerSupport implements OrderlyShutdownCapable {
+
+	public static final String KAFKA_MESSAGE_KEY = "kafka.message.key";
+
+	public static final String KAFKA_MESSAGE_TOPIC = "kafka.message.topic";
+
+	public static final String KAFKA_MESSAGE_PARTITION = "kafka.message.partition.id";
+
+	public static final String KAFKA_MESSAGE_OFFSET = "kafka.message.offset";
+
+	private KafkaMessageListenerContainer messageListenerContainer;
+
+	private Decoder<?> keyDecoder = new DefaultDecoder(null);
+
+	private Decoder<?> payloadDecoder = new DefaultDecoder(null);
+
+	public KafkaInboundChannelAdapter(KafkaMessageListenerContainer messageListenerContainer) {
+		Assert.notNull(messageListenerContainer);
+		Assert.isNull(messageListenerContainer.getMessageListener());
+		this.messageListenerContainer = messageListenerContainer;
+		this.messageListenerContainer.setAutoStartup(false);
+	}
+
+	public Decoder<?> getKeyDecoder() {
+		return keyDecoder;
+	}
+
+	public void setKeyDecoder(Decoder<?> keyDecoder) {
+		this.keyDecoder = keyDecoder;
+	}
+
+	public Decoder<?> getPayloadDecoder() {
+		return payloadDecoder;
+	}
+
+	public void setPayloadDecoder(Decoder<?> payloadDecoder) {
+		this.payloadDecoder = payloadDecoder;
+	}
+
+	@Override
+	protected void doStart() {
+		this.messageListenerContainer.start();
+	}
+
+	@Override
+	protected void doStop() {
+		this.messageListenerContainer.stop();
+	}
+
+	@Override
+	protected void onInit() {
+		this.messageListenerContainer.setMessageListener(new ChannelForwardingMessageListener());
+		super.onInit();
+	}
+
+	@Override
+	public String getComponentType() {
+		return "amqp:inbound-channel-adapter";
+	}
+
+	@Override
+	public int beforeShutdown() {
+		this.messageListenerContainer.stop();
+		return 0;
+	}
+
+	@Override
+	public int afterShutdown() {
+		return 0;
+	}
+
+	private class ChannelForwardingMessageListener extends AbstractDecodingMessageListener {
+
+		public ChannelForwardingMessageListener() {
+			super(keyDecoder, payloadDecoder);
+		}
+
+		@Override
+		public void doOnMessage(Object key, Object payload, KafkaMessageMetadata metadata) {
+			Message<Object> message = MessageBuilder
+					.withPayload(payload)
+					.setHeader(KAFKA_MESSAGE_KEY, key)
+					.setHeader(KAFKA_MESSAGE_TOPIC, metadata.getPartition().getTopic())
+					.setHeader(KAFKA_MESSAGE_PARTITION, metadata.getPartition().getId())
+					.setHeader(KAFKA_MESSAGE_OFFSET, metadata.getOffset())
+					.build();
+			KafkaInboundChannelAdapter.this.sendMessage(message);
+		}
+	}
+}

--- a/src/main/java/org/springframework/integration/kafka/inbound/KafkaInboundChannelAdapter.java
+++ b/src/main/java/org/springframework/integration/kafka/inbound/KafkaInboundChannelAdapter.java
@@ -72,6 +72,12 @@ public class KafkaInboundChannelAdapter extends MessageProducerSupport implement
 	}
 
 	@Override
+	protected void onInit() {
+		this.messageListenerContainer.setMessageListener(new ChannelForwardingMessageListener());
+		super.onInit();
+	}
+
+	@Override
 	protected void doStart() {
 		this.messageListenerContainer.start();
 	}
@@ -79,12 +85,6 @@ public class KafkaInboundChannelAdapter extends MessageProducerSupport implement
 	@Override
 	protected void doStop() {
 		this.messageListenerContainer.stop();
-	}
-
-	@Override
-	protected void onInit() {
-		this.messageListenerContainer.setMessageListener(new ChannelForwardingMessageListener());
-		super.onInit();
 	}
 
 	@Override

--- a/src/main/java/org/springframework/integration/kafka/listener/AbstractDecodingMessageListener.java
+++ b/src/main/java/org/springframework/integration/kafka/listener/AbstractDecodingMessageListener.java
@@ -30,7 +30,7 @@ import org.springframework.util.Assert;
 /**
  * @author Marius Bogoevici
  */
-public abstract class AbstractDecodingMessageListener<K,P> implements MessageListener, InitializingBean {
+public abstract class AbstractDecodingMessageListener<K, P> implements MessageListener, InitializingBean {
 
 	private Decoder<K> keyDecoder;
 

--- a/src/main/java/org/springframework/integration/kafka/listener/AbstractDecodingMessageListener.java
+++ b/src/main/java/org/springframework/integration/kafka/listener/AbstractDecodingMessageListener.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.springframework.integration.kafka.listener;
+
+import static org.springframework.integration.kafka.util.MessageUtils.decodeKey;
+import static org.springframework.integration.kafka.util.MessageUtils.decodePayload;
+
+import kafka.serializer.Decoder;
+
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.integration.kafka.core.KafkaMessage;
+import org.springframework.integration.kafka.core.KafkaMessageMetadata;
+import org.springframework.util.Assert;
+
+/**
+ * @author Marius Bogoevici
+ */
+public abstract class AbstractDecodingMessageListener<K,P> implements MessageListener, InitializingBean {
+
+	private Decoder<K> keyDecoder;
+
+	private Decoder<P> payloadDecoder;
+
+	public AbstractDecodingMessageListener(Decoder<K> keyDecoder, Decoder<P> payloadDecoder) {
+		this.keyDecoder = keyDecoder;
+		this.payloadDecoder = payloadDecoder;
+	}
+
+	public Decoder<K> getKeyDecoder() {
+		return keyDecoder;
+	}
+
+	public void setKeyDecoder(Decoder<K> keyDecoder) {
+		this.keyDecoder = keyDecoder;
+	}
+
+	public Decoder<P> getPayloadDecoder() {
+		return payloadDecoder;
+	}
+
+	public void setPayloadDecoder(Decoder<P> payloadDecoder) {
+		this.payloadDecoder = payloadDecoder;
+	}
+
+	@Override
+	public void afterPropertiesSet() throws Exception {
+		Assert.notNull(keyDecoder, "Key decoder decoder cannot be null");
+		Assert.notNull(payloadDecoder, "Payload decoder cannot be null");
+	}
+
+	@Override
+	public final void onMessage(KafkaMessage message) {
+		this.doOnMessage(decodeKey(message, keyDecoder), decodePayload(message, payloadDecoder), message.getMetadata());
+	}
+
+	public abstract void doOnMessage(K key, P payload, KafkaMessageMetadata metadata);
+
+}

--- a/src/main/java/org/springframework/integration/kafka/listener/AbstractDefaultDecodingMessageListener.java
+++ b/src/main/java/org/springframework/integration/kafka/listener/AbstractDefaultDecodingMessageListener.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.springframework.integration.kafka.listener;
+
+import kafka.serializer.Decoder;
+import kafka.serializer.DefaultDecoder;
+import kafka.utils.VerifiableProperties;
+
+/**
+ * @author Marius Bogoevici
+ */
+public abstract class AbstractDefaultDecodingMessageListener extends AbstractDecodingMessageListener<byte[], byte[]> {
+
+	public static final Decoder<byte[]> DEFAULT_DECODER = new DefaultDecoder(new VerifiableProperties());
+
+	public AbstractDefaultDecodingMessageListener() {
+		super(DEFAULT_DECODER, DEFAULT_DECODER);
+	}
+}

--- a/src/main/java/org/springframework/integration/kafka/listener/ConcurrentMessageListenerDispatcher.java
+++ b/src/main/java/org/springframework/integration/kafka/listener/ConcurrentMessageListenerDispatcher.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.springframework.integration.kafka.listener;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+import com.gs.collections.api.block.procedure.Procedure;
+import com.gs.collections.api.map.MutableMap;
+import com.gs.collections.impl.factory.Maps;
+
+import org.springframework.context.Lifecycle;
+import org.springframework.integration.kafka.core.Partition;
+import org.springframework.integration.kafka.core.KafkaMessage;
+import org.springframework.scheduling.concurrent.CustomizableThreadFactory;
+import org.springframework.util.Assert;
+
+/**
+ * Dispatches {@link KafkaMessage}s across a set of MessageListeners.
+ *
+ * @author Marius Bogoevici
+ */
+public class ConcurrentMessageListenerDispatcher implements Lifecycle {
+
+	public static final CustomizableThreadFactory THREAD_FACTORY = new CustomizableThreadFactory("dispatcher-");
+
+	private final Object lifecycleMonitor = new Object();
+
+	private volatile boolean running;
+
+	private MessageListener delegateListener;
+
+	private final Partition[] partitions;
+
+	private final int consumers;
+
+	private OffsetManager offsetManager;
+
+	private MutableMap<Partition,QueueingMessageListenerInvoker> delegates;
+
+	private int queueSize = 1024;
+
+	private Executor taskExecutor;
+
+	private ErrorHandler errorHandler = new LoggingErrorHandler();
+
+	public ConcurrentMessageListenerDispatcher(MessageListener delegateListener, Partition[] partitions, int consumers, OffsetManager offsetManager) {
+		Assert.notEmpty(partitions, "A set of partitions must be provided");
+		Assert.isTrue(consumers <= partitions.length, "Consumers must be fewer than partitions");
+		Assert.notNull(delegateListener, "A delegate must be provided");
+		this.delegateListener = delegateListener;
+		this.partitions = partitions;
+		this.consumers = consumers;
+		this.offsetManager = offsetManager;
+	}
+
+	public ErrorHandler getErrorHandler() {
+		return errorHandler;
+	}
+
+	public void setErrorHandler(ErrorHandler errorHandler) {
+		this.errorHandler = errorHandler;
+	}
+
+	public OffsetManager getOffsetManager() {
+		return offsetManager;
+	}
+
+	public void setOffsetManager(OffsetManager offsetManager) {
+		this.offsetManager = offsetManager;
+	}
+
+	public int getQueueSize() {
+		return queueSize;
+	}
+
+	public void setQueueSize(int queueSize) {
+		this.queueSize = queueSize;
+	}
+
+	@Override
+	public void start() {
+		synchronized (lifecycleMonitor) {
+			if (!isRunning()) {
+				initializeAndStartDispatching();
+				this.running = true;
+			}
+		}
+	}
+
+	@Override
+	public void stop() {
+		synchronized (lifecycleMonitor) {
+			if (isRunning()) {
+				this.running = false;
+				delegates.forEachValue(new Procedure<QueueingMessageListenerInvoker>() {
+					@Override
+					public void value(QueueingMessageListenerInvoker delegate) {
+						delegate.stop();
+					}
+				});
+			}
+		}
+	}
+
+	@Override
+	public boolean isRunning() {
+		return running;
+	}
+
+	public void dispatch(KafkaMessage message) {
+			delegates.get(message.getMetadata().getPartition()).enqueue(message);
+	}
+
+	private void initializeAndStartDispatching() {
+		// allocate delegate instances index them
+		List<QueueingMessageListenerInvoker> delegateList = new ArrayList<QueueingMessageListenerInvoker>(consumers);
+		for (int i = 0; i < consumers; i++) {
+			QueueingMessageListenerInvoker blockingQueueMessageListenerInvoker = new QueueingMessageListenerInvoker(queueSize, offsetManager, delegateListener);
+			if (errorHandler != null) {
+				blockingQueueMessageListenerInvoker.setErrorHandler(errorHandler);
+			}
+			delegateList.add(blockingQueueMessageListenerInvoker);
+		}
+		// evenly distribute partitions across delegates
+		delegates = Maps.mutable.of();
+		for (int i = 0; i < partitions.length; i++) {
+			delegates.put(partitions[i], delegateList.get(i % consumers));
+		}
+		// initialize task executor
+		if (this.taskExecutor == null) {
+			this.taskExecutor = Executors.newFixedThreadPool(consumers, THREAD_FACTORY);
+		}
+		// start dispatchers
+		delegates.flip().keyBag().toSet().forEach(new Procedure<QueueingMessageListenerInvoker>() {
+			@Override
+			public void value(QueueingMessageListenerInvoker delegate) {
+				delegate.start();
+				taskExecutor.execute(delegate);
+			}
+		});
+	}
+
+}

--- a/src/main/java/org/springframework/integration/kafka/listener/ConcurrentMessageListenerDispatcher.java
+++ b/src/main/java/org/springframework/integration/kafka/listener/ConcurrentMessageListenerDispatcher.java
@@ -27,8 +27,8 @@ import com.gs.collections.api.map.MutableMap;
 import com.gs.collections.impl.factory.Maps;
 
 import org.springframework.context.Lifecycle;
-import org.springframework.integration.kafka.core.Partition;
 import org.springframework.integration.kafka.core.KafkaMessage;
+import org.springframework.integration.kafka.core.Partition;
 import org.springframework.scheduling.concurrent.CustomizableThreadFactory;
 import org.springframework.util.Assert;
 
@@ -43,17 +43,17 @@ public class ConcurrentMessageListenerDispatcher implements Lifecycle {
 
 	private final Object lifecycleMonitor = new Object();
 
-	private volatile boolean running;
-
-	private MessageListener delegateListener;
-
 	private final Partition[] partitions;
 
 	private final int consumers;
 
+	private volatile boolean running;
+
+	private MessageListener delegateListener;
+
 	private OffsetManager offsetManager;
 
-	private MutableMap<Partition,QueueingMessageListenerInvoker> delegates;
+	private MutableMap<Partition, QueueingMessageListenerInvoker> delegates;
 
 	private int queueSize = 1024;
 
@@ -126,7 +126,7 @@ public class ConcurrentMessageListenerDispatcher implements Lifecycle {
 	}
 
 	public void dispatch(KafkaMessage message) {
-			delegates.get(message.getMetadata().getPartition()).enqueue(message);
+		delegates.get(message.getMetadata().getPartition()).enqueue(message);
 	}
 
 	private void initializeAndStartDispatching() {

--- a/src/main/java/org/springframework/integration/kafka/listener/DeadLetterQueueErrorHandler.java
+++ b/src/main/java/org/springframework/integration/kafka/listener/DeadLetterQueueErrorHandler.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.springframework.integration.kafka.listener;
+
+import org.springframework.integration.kafka.core.KafkaMessage;
+import org.springframework.messaging.MessageChannel;
+
+/**
+ * @author Marius Bogoevici
+ */
+public class DeadLetterQueueErrorHandler implements ErrorHandler {
+
+	private MessageChannel dlqChannel;
+
+	public MessageChannel getDlqChannel() {
+		return dlqChannel;
+	}
+
+	public void setDlqChannel(MessageChannel dlqChannel) {
+		this.dlqChannel = dlqChannel;
+	}
+
+	@Override
+	public void handle(Exception thrownException, KafkaMessage message) {
+
+	}
+}

--- a/src/main/java/org/springframework/integration/kafka/listener/ErrorHandler.java
+++ b/src/main/java/org/springframework/integration/kafka/listener/ErrorHandler.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.springframework.integration.kafka.listener;
+
+import org.springframework.integration.kafka.core.KafkaMessage;
+
+/**
+ * @author Marius Bogoevici
+ */
+public interface ErrorHandler {
+
+	void handle(Exception thrownException, KafkaMessage message);
+
+}

--- a/src/main/java/org/springframework/integration/kafka/listener/KafkaMessageListenerContainer.java
+++ b/src/main/java/org/springframework/integration/kafka/listener/KafkaMessageListenerContainer.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.springframework.integration.kafka.listener;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+import com.gs.collections.api.RichIterable;
+import com.gs.collections.api.block.function.Function;
+import com.gs.collections.api.block.procedure.Procedure2;
+import com.gs.collections.api.list.ImmutableList;
+import com.gs.collections.api.list.MutableList;
+import com.gs.collections.api.map.MutableMap;
+import com.gs.collections.impl.block.factory.Functions;
+import com.gs.collections.impl.block.function.checked.CheckedFunction;
+import com.gs.collections.impl.factory.Lists;
+import com.gs.collections.impl.utility.ArrayIterate;
+
+import org.springframework.context.SmartLifecycle;
+import org.springframework.integration.kafka.core.KafkaBrokerAddress;
+import org.springframework.integration.kafka.core.KafkaBrokerConnectionFactory;
+import org.springframework.integration.kafka.core.Partition;
+import org.springframework.integration.kafka.core.KafkaMessage;
+import org.springframework.integration.kafka.core.KafkaMessageBatch;
+import org.springframework.integration.kafka.core.KafkaMessageFetchRequest;
+import org.springframework.integration.kafka.core.KafkaTemplate;
+import org.springframework.util.Assert;
+
+/**
+ * @author Marius Bogoevici
+ */
+public class KafkaMessageListenerContainer implements SmartLifecycle {
+
+	private final GetOffsetForPartition getOffset = new GetOffsetForPartition();
+
+	private final GetLeaderFunction getLeader = new GetLeaderFunction();
+
+	private final Function<Partition, Partition> passThru = Functions.getPassThru();
+
+	private final LaunchFetchTaskProcedure launchFetchTask = new LaunchFetchTaskProcedure();
+
+	private final Object lifecycleMonitor = new Object();
+
+	private final KafkaTemplate kafkaTemplate;
+
+	private final ImmutableList<Partition> partitions;
+
+	private Executor taskExecutor;
+
+	private int concurrency = 1;
+
+	private volatile boolean running = false;
+
+	public boolean autoStartup = true;
+
+	private long timeout = 100L;
+
+	private int maxSize = 10000;
+
+	private MessageListener messageListener;
+
+	private volatile OffsetManager offsetManager;
+
+	private ConcurrentMap<Partition, Long> fetchOffsets;
+
+	private ConcurrentMessageListenerDispatcher messageDispatcher;
+
+
+	public KafkaMessageListenerContainer(KafkaBrokerConnectionFactory kafkaBrokerConnectionFactory, Partition[] partitions) {
+		Assert.notNull(kafkaBrokerConnectionFactory, "A connection factory must be supplied");
+		Assert.notEmpty(partitions, "A list of partitions must be provided");
+		this.kafkaTemplate = new KafkaTemplate(kafkaBrokerConnectionFactory);
+		this.partitions = Lists.immutable.with(partitions);
+	}
+
+	public KafkaMessageListenerContainer(final KafkaBrokerConnectionFactory kafkaBrokerConnectionFactory, String[] topics) {
+		this(kafkaBrokerConnectionFactory, getPartitionsForTopics(kafkaBrokerConnectionFactory, topics));
+	}
+
+
+	public OffsetManager getOffsetManager() {
+		return offsetManager;
+	}
+	public void setOffsetManager(OffsetManager offsetManager) {
+		this.offsetManager = offsetManager;
+	}
+
+	public MessageListener getMessageListener() {
+		return messageListener;
+	}
+
+	public void setMessageListener(MessageListener messageListener) {
+		this.messageListener = messageListener;
+	}
+
+	public int getConcurrency() {
+		return concurrency;
+	}
+
+	public void setConcurrency(int concurrency) {
+		this.concurrency = concurrency;
+	}
+
+	public int getMaxSize() {
+		return maxSize;
+	}
+
+	public void setMaxSize(int maxSize) {
+		this.maxSize = maxSize;
+	}
+
+	public long getTimeout() {
+		return timeout;
+	}
+
+	public void setTimeout(long timeout) {
+		this.timeout = timeout;
+	}
+
+	@Override
+	public boolean isAutoStartup() {
+		return autoStartup;
+	}
+
+	public void setAutoStartup(boolean autoStartup) {
+		this.autoStartup = autoStartup;
+	}
+
+	@Override
+	public void stop(Runnable callback) {
+		synchronized (lifecycleMonitor) {
+			if (running) {
+				this.running = false;
+				this.messageDispatcher.stop();
+			}
+		}
+	}
+	@Override
+	public void start() {
+		synchronized (lifecycleMonitor) {
+			if (!running) {
+				this.running = true;
+				if (this.offsetManager == null) {
+					this.offsetManager = new MetadataStoreOffsetManager(kafkaTemplate.getKafkaBrokerConnectionFactory());
+				}
+				// initialize the fetch offset table - defer to OffsetManager for retrieving them
+				this.fetchOffsets = new ConcurrentHashMap<Partition, Long>(this.partitions.toMap(passThru, getOffset));
+				this.messageDispatcher = new ConcurrentMessageListenerDispatcher(messageListener, partitions.toArray(new Partition[partitions.size()]), concurrency, offsetManager);
+				this.messageDispatcher.start();
+				MutableMap<KafkaBrokerAddress, RichIterable<Partition>> partitionsByBrokerMap = this.partitions.groupBy(getLeader).toMap();
+				if (taskExecutor == null) {
+					taskExecutor = Executors.newFixedThreadPool(partitionsByBrokerMap.size());
+				}
+				partitionsByBrokerMap.forEachKeyValue(launchFetchTask);
+			}
+		}
+	}
+
+	@Override
+	public void stop() {
+		this.stop(null);
+	}
+
+	@Override
+	public boolean isRunning() {
+			return this.running;
+	}
+
+	@Override
+	public int getPhase() {
+		return 0;
+	}
+
+	private static Partition[] getPartitionsForTopics(final KafkaBrokerConnectionFactory kafkaBrokerConnectionFactory, String[] topics) {
+		MutableList<Partition> partitionList = ArrayIterate.flatCollect(topics, new GetPartitionsForTopic(kafkaBrokerConnectionFactory));
+		return partitionList.toArray(new Partition[partitionList.size()]);
+	}
+
+	/**
+	 * Fetches data from Kafka for a group of partitions, located on the same broker.
+	 *
+	 */
+	public class FetchTask implements Runnable {
+
+		private MutableList<Partition> partitions;
+
+		public FetchTask(MutableList<Partition> partition) {
+			this.partitions = partition;
+		}
+
+		@Override
+		public void run() {
+			KafkaMessageListenerContainer kafkaMessageListenerContainer = KafkaMessageListenerContainer.this;
+			while (running) {
+				Set<Partition> partitionsWithRemainingData;
+				do {
+					partitionsWithRemainingData = new HashSet<Partition>();
+					Iterable<KafkaMessageBatch> receive = kafkaTemplate.receive(this.partitions.collect(new Function<Partition, KafkaMessageFetchRequest>() {
+						@Override
+						public KafkaMessageFetchRequest valueOf(Partition partition) {
+							return new KafkaMessageFetchRequest(partition, fetchOffsets.get(partition), maxSize);
+						}
+					}).toArray(new KafkaMessageFetchRequest[0]));
+					for (KafkaMessageBatch batch : receive) {
+						if (!batch.getMessages().isEmpty()) {
+							long highestFetchedOffset = 0;
+							for (KafkaMessage kafkaMessage : batch.getMessages()) {
+								// fetch operations may return entire blocks of compressed messages, which may have lower offsets than the ones requested
+								// thus a batch may contain messages that have been processed already
+								if (kafkaMessage.getMetadata().getOffset() >= fetchOffsets.get(batch.getPartition())) {
+									messageDispatcher.dispatch(kafkaMessage);
+								}
+								highestFetchedOffset = Math.max(highestFetchedOffset, kafkaMessage.getMetadata().getNextOffset());
+							}
+							fetchOffsets.replace(batch.getPartition(), highestFetchedOffset);
+							// if there are still messages on server, we can go on and retrieve more
+							if (highestFetchedOffset < batch.getHighWatermark()) {
+								partitionsWithRemainingData.add(batch.getPartition());
+							}
+						}
+					}
+				} while (!partitionsWithRemainingData.isEmpty());
+				try {
+					Thread.currentThread().sleep(timeout);
+				}
+				catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+				}
+			}
+		}
+	}
+
+
+	static class GetPartitionsForTopic extends CheckedFunction<String, Iterable<Partition>> {
+
+		private final KafkaBrokerConnectionFactory kafkaBrokerConnectionFactory;
+
+		public GetPartitionsForTopic(KafkaBrokerConnectionFactory kafkaBrokerConnectionFactory) {
+			this.kafkaBrokerConnectionFactory = kafkaBrokerConnectionFactory;
+		}
+
+		@Override
+		public Iterable<Partition> safeValueOf(String topic) throws Exception {
+			return kafkaBrokerConnectionFactory.getPartitions(topic);
+		}
+	}
+
+	class GetOffsetForPartition extends CheckedFunction<Partition, Long> {
+		@Override
+		public Long safeValueOf(Partition object) throws Exception {
+			return offsetManager.getOffset(object);
+		}
+	}
+
+	private class GetLeaderFunction implements Function<Partition, KafkaBrokerAddress> {
+		@Override
+		public KafkaBrokerAddress valueOf(Partition partition) {
+			return kafkaTemplate.getKafkaBrokerConnectionFactory().getLeader(partition);
+		}
+	}
+
+	private class LaunchFetchTaskProcedure implements Procedure2<KafkaBrokerAddress, RichIterable<Partition>> {
+		@Override
+		public void value(KafkaBrokerAddress brokerAddress, RichIterable<Partition> partitions) {
+			taskExecutor.execute(new FetchTask(partitions.toList()));
+		}
+	}
+}

--- a/src/main/java/org/springframework/integration/kafka/listener/LoggingErrorHandler.java
+++ b/src/main/java/org/springframework/integration/kafka/listener/LoggingErrorHandler.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.springframework.integration.kafka.listener;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.integration.kafka.core.KafkaMessage;
+
+/**
+* @author Marius Bogoevici
+*/
+class LoggingErrorHandler implements ErrorHandler {
+
+	private static final Log LOGGER = LogFactory.getLog(LoggingErrorHandler.class);
+
+	@Override
+	public void handle(Exception thrownException, KafkaMessage message) {
+		LOGGER.error(thrownException);
+	}
+
+}

--- a/src/main/java/org/springframework/integration/kafka/listener/LoggingErrorHandler.java
+++ b/src/main/java/org/springframework/integration/kafka/listener/LoggingErrorHandler.java
@@ -23,8 +23,8 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.integration.kafka.core.KafkaMessage;
 
 /**
-* @author Marius Bogoevici
-*/
+ * @author Marius Bogoevici
+ */
 class LoggingErrorHandler implements ErrorHandler {
 
 	private static final Log LOGGER = LogFactory.getLog(LoggingErrorHandler.class);

--- a/src/main/java/org/springframework/integration/kafka/listener/MessageListener.java
+++ b/src/main/java/org/springframework/integration/kafka/listener/MessageListener.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.springframework.integration.kafka.listener;
+
+import org.springframework.integration.kafka.core.KafkaMessage;
+
+/**
+ * @author Marius Bogoevici
+ */
+public interface MessageListener {
+
+	void onMessage(KafkaMessage message);
+
+}

--- a/src/main/java/org/springframework/integration/kafka/listener/MetadataStoreOffsetManager.java
+++ b/src/main/java/org/springframework/integration/kafka/listener/MetadataStoreOffsetManager.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.springframework.integration.kafka.listener;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import com.gs.collections.api.RichIterable;
+import com.gs.collections.api.block.function.Function;
+import com.gs.collections.api.block.procedure.Procedure2;
+import com.gs.collections.api.map.MutableMap;
+import com.gs.collections.api.multimap.MutableMultimap;
+import com.gs.collections.impl.map.mutable.ConcurrentHashMap;
+import com.gs.collections.impl.utility.Iterate;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.integration.kafka.core.KafkaBrokerAddress;
+import org.springframework.integration.kafka.core.KafkaBrokerConnectionFactory;
+import org.springframework.integration.kafka.core.KafkaResult;
+import org.springframework.integration.kafka.core.Partition;
+import org.springframework.integration.metadata.MetadataStore;
+import org.springframework.integration.metadata.SimpleMetadataStore;
+import org.springframework.util.CollectionUtils;
+
+/**
+ * An {@link org.springframework.integration.kafka.simple.offset.OffsetManager} that persists offsets into
+ * a {@link org.springframework.integration.metadata.MetadataStore}
+ *
+ * @author Marius Bogoevici
+ */
+public class MetadataStoreOffsetManager implements OffsetManager {
+
+	private final static Log LOG = LogFactory.getLog(MetadataStoreOffsetManager.class);
+
+	private String consumerId = "spring.kafka";
+
+	private MetadataStore metadataStore = new SimpleMetadataStore();
+
+	private KafkaBrokerConnectionFactory kafkaBrokerConnectionFactory;
+
+	private long referenceTimestamp = -2;
+
+	private MutableMap<Partition, Long> offsets = new ConcurrentHashMap<Partition, Long>();
+
+	public MetadataStoreOffsetManager(KafkaBrokerConnectionFactory kafkaBrokerConnectionFactory) {
+		this(kafkaBrokerConnectionFactory, null);
+	}
+
+	public MetadataStoreOffsetManager(KafkaBrokerConnectionFactory kafkaBrokerConnectionFactory, Map<Partition, Long> initialOffsets) {
+		this.kafkaBrokerConnectionFactory = kafkaBrokerConnectionFactory;
+		loadOffsets(initialOffsets);
+	}
+
+	public String getConsumerId() {
+		return consumerId;
+	}
+
+	/**
+	 * The identifier of a consumer of Kafka messages. Allows to store separate sets of offsets in the {@link MetadataStore}.
+	 *
+	 * @param consumerId the consumer ID
+	 */
+	public void setConsumerId(String consumerId) {
+		this.consumerId = consumerId;
+	}
+
+	public MetadataStore getMetadataStore() {
+		return metadataStore;
+	}
+
+	/**
+	 * The backing {@link MetadataStore} for storing offsets.
+	 *
+	 * @param metadataStore a fully configured {@link MetadataStore} instance
+	 */
+	public void setMetadataStore(MetadataStore metadataStore) {
+		this.metadataStore = metadataStore;
+	}
+
+	public long getReferenceTimestamp() {
+		return referenceTimestamp;
+	}
+
+	/**
+	 * A timestamp to be used for resetting initial offsets, if they are not available in the {@link MetadataStore}
+	 *
+	 * @param referenceTimestamp
+	 */
+	public void setReferenceTimestamp(long referenceTimestamp) {
+		this.referenceTimestamp = referenceTimestamp;
+	}
+
+	/**
+	 * @see {@link OffsetManager#updateOffset(Partition, long)}
+	 */
+	@Override
+	public void updateOffset(Partition partition, long offset) {
+		metadataStore.put(asKey(partition), Long.toString(offset));
+		offsets.put(partition, offset);
+	}
+
+	/**
+	 * @see {@link OffsetManager#getOffset(Partition)}
+	 */
+	@Override
+	public long getOffset(Partition partition) {
+		return offsets.get(partition);
+	}
+
+	private void loadOffsets(Map<Partition, Long> initialOffsets) {
+		if (!CollectionUtils.isEmpty(initialOffsets)) {
+			this.offsets = ConcurrentHashMap.newMap(initialOffsets);
+		} else {
+			this.offsets = ConcurrentHashMap.newMap();
+		}
+		List<Partition> partitionsRequiringInitialOffsets = new ArrayList<Partition>();
+		for (Partition partition : kafkaBrokerConnectionFactory.getPartitions()) {
+			if (!this.offsets.containsKey(partition)) {
+				String storedOffsetValueAsString = this.metadataStore.get(asKey(partition));
+				Long storedOffsetValue = null;
+				if (storedOffsetValueAsString != null) {
+					try {
+						storedOffsetValue = Long.parseLong(storedOffsetValueAsString);
+					}
+					catch (NumberFormatException e) {
+						LOG.warn("Invalid value: " + storedOffsetValue);
+					}
+				}
+				if (storedOffsetValue != null) {
+					offsets.put(partition, storedOffsetValue);
+				} else {
+					partitionsRequiringInitialOffsets.add(partition);
+				}
+			}
+		}
+		if (partitionsRequiringInitialOffsets.size() > 0) {
+			MutableMultimap<KafkaBrokerAddress, Partition> partitionsByLeaderAddress = Iterate.groupBy(partitionsRequiringInitialOffsets, new Function<Partition, KafkaBrokerAddress>() {
+				@Override
+				public KafkaBrokerAddress valueOf(Partition object) {
+					return kafkaBrokerConnectionFactory.getLeader(object);
+				}
+			});
+			partitionsByLeaderAddress.toMap().forEachKeyValue(new Procedure2<KafkaBrokerAddress, RichIterable<Partition>>() {
+				@Override
+				public void value(KafkaBrokerAddress kafkaBrokerAddress, RichIterable<Partition> partitions) {
+					KafkaResult<Long> initialOffsets = kafkaBrokerConnectionFactory.createConnection(kafkaBrokerAddress).fetchInitialOffset(referenceTimestamp, partitions.toArray(new Partition[partitions.size()]));
+					if (initialOffsets.getErrors().size() == 0) {
+						for (Partition partition : partitions) {
+							offsets.put(partition, initialOffsets.getResults().get(partition));
+						}
+					} else {
+						throw new IllegalStateException("Cannot load initial offsets");
+					}
+				}
+			});
+
+		}
+	}
+
+	private String asKey(Partition partition) {
+		return partition.getTopic() + " " + partition.getId() + " " + consumerId;
+	}
+}

--- a/src/main/java/org/springframework/integration/kafka/listener/OffsetManager.java
+++ b/src/main/java/org/springframework/integration/kafka/listener/OffsetManager.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.springframework.integration.kafka.listener;
+
+import org.springframework.integration.kafka.core.Partition;
+
+/**
+ * Stores and retrieves offsets for a Kafka consumer
+ *
+ * @author Marius Bogoevici
+ */
+public interface OffsetManager {
+
+	void updateOffset(Partition partition, long offset);
+
+	long getOffset(Partition partition);
+}

--- a/src/main/java/org/springframework/integration/kafka/listener/QueueingMessageListenerInvoker.java
+++ b/src/main/java/org/springframework/integration/kafka/listener/QueueingMessageListenerInvoker.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.springframework.integration.kafka.listener;
+
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+
+import org.springframework.context.Lifecycle;
+import org.springframework.integration.kafka.core.KafkaMessage;
+
+/**
+ * Invokes a delegate {@link MessageListener} for all the messages passed to it, storing them
+ * in an internal queue.
+ *
+ * @author Marius Bogoevici
+ */
+public class QueueingMessageListenerInvoker implements Runnable,Lifecycle {
+
+	private BlockingQueue<KafkaMessage> messages;
+
+	private volatile boolean running = false;
+
+	private MessageListener delegate;
+
+	private OffsetManager offsetManager;
+
+	private ErrorHandler errorHandler = new LoggingErrorHandler();
+
+	public QueueingMessageListenerInvoker(int capacity, OffsetManager offsetManager, MessageListener delegate) {
+		this.offsetManager = offsetManager;
+		this.delegate = delegate;
+		this.messages = new ArrayBlockingQueue<KafkaMessage>(capacity, true);
+	}
+
+	public void enqueue(KafkaMessage message) {
+		try {
+			this.messages.put(message);
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			if (this.isRunning()) {
+				this.enqueue(message);
+			}
+		}
+	}
+
+	public ErrorHandler getErrorHandler() {
+		return errorHandler;
+	}
+
+	public void setErrorHandler(ErrorHandler errorHandler) {
+		this.errorHandler = errorHandler;
+	}
+
+	@Override
+	public void start() {
+		this.running = true;
+	}
+
+	@Override
+	public void stop() {
+		this.running =false;
+	}
+
+	@Override
+	public boolean isRunning() {
+		return this.running;
+	}
+
+	@Override
+	public void run() {
+		while(this.running) {
+			try {
+				KafkaMessage message = messages.take();
+				try {
+					delegate.onMessage(message);
+				}
+				catch (Exception e) {
+					errorHandler.handle(e, message);
+				} finally {
+					offsetManager.updateOffset(message.getMetadata().getPartition(), message.getMetadata().getNextOffset());
+				}
+			}
+			catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+			}
+		}
+	}
+}

--- a/src/main/java/org/springframework/integration/kafka/listener/QueueingMessageListenerInvoker.java
+++ b/src/main/java/org/springframework/integration/kafka/listener/QueueingMessageListenerInvoker.java
@@ -29,7 +29,7 @@ import org.springframework.integration.kafka.core.KafkaMessage;
  *
  * @author Marius Bogoevici
  */
-public class QueueingMessageListenerInvoker implements Runnable,Lifecycle {
+public class QueueingMessageListenerInvoker implements Runnable, Lifecycle {
 
 	private BlockingQueue<KafkaMessage> messages;
 
@@ -74,7 +74,7 @@ public class QueueingMessageListenerInvoker implements Runnable,Lifecycle {
 
 	@Override
 	public void stop() {
-		this.running =false;
+		this.running = false;
 	}
 
 	@Override
@@ -84,7 +84,7 @@ public class QueueingMessageListenerInvoker implements Runnable,Lifecycle {
 
 	@Override
 	public void run() {
-		while(this.running) {
+		while (this.running) {
 			try {
 				KafkaMessage message = messages.take();
 				try {
@@ -92,7 +92,8 @@ public class QueueingMessageListenerInvoker implements Runnable,Lifecycle {
 				}
 				catch (Exception e) {
 					errorHandler.handle(e, message);
-				} finally {
+				}
+				finally {
 					offsetManager.updateOffset(message.getMetadata().getPartition(), message.getMetadata().getNextOffset());
 				}
 			}

--- a/src/main/java/org/springframework/integration/kafka/util/MessageUtils.java
+++ b/src/main/java/org/springframework/integration/kafka/util/MessageUtils.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.springframework.integration.kafka.util;
+
+import kafka.serializer.Decoder;
+import kafka.utils.Utils$;
+
+import org.springframework.integration.kafka.core.KafkaMessage;
+
+/**
+ * @author Marius Bogoevici
+ */
+public class MessageUtils {
+
+	public static <T> T decodeKey(KafkaMessage message, Decoder<T> decoder) {
+		if (message.getMessage().isNull() || !message.getMessage().hasKey()) {
+			return null;
+		}
+		return decoder.fromBytes(Utils$.MODULE$.readBytes(message.getMessage().key()));
+	}
+
+	public static <T> T decodePayload(KafkaMessage message, Decoder<T> decoder) {
+		if (message.getMessage().isNull()) {
+			return null;
+		}
+		return decoder.fromBytes(Utils$.MODULE$.readBytes(message.getMessage().payload()));
+	}
+}

--- a/src/test/java/org/springframework/integration/kafka/listener/AbstractBrokerTest.java
+++ b/src/test/java/org/springframework/integration/kafka/listener/AbstractBrokerTest.java
@@ -85,8 +85,12 @@ public abstract class AbstractBrokerTest {
 	}
 
 	public static scala.collection.Seq<KeyedMessage<String, String>> createMessages(int count) {
+		return createMessagesInRange(0,count-1);
+	}
+
+	public static scala.collection.Seq<KeyedMessage<String, String>> createMessagesInRange(int start, int end) {
 		List<KeyedMessage<String,String>> messages = new ArrayList<KeyedMessage<String, String>>();
-		for (int i=0; i<count; i++) {
+		for (int i=start; i<= end; i++) {
 			messages.add(new KeyedMessage<String, String>(TEST_TOPIC, "Key " + i, i, "Message " + i));
 		}
 		return asScalaBuffer(messages).toSeq();

--- a/src/test/java/org/springframework/integration/kafka/listener/AbstractBrokerTest.java
+++ b/src/test/java/org/springframework/integration/kafka/listener/AbstractBrokerTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.springframework.integration.kafka.listener;
+
+import static scala.collection.JavaConversions.asScalaBuffer;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+import com.gs.collections.api.RichIterable;
+import com.gs.collections.api.block.function.Function2;
+import com.gs.collections.api.multimap.Multimap;
+import com.gs.collections.api.multimap.MutableMultimap;
+import com.gs.collections.api.tuple.Pair;
+import com.gs.collections.impl.factory.Multimaps;
+import com.gs.collections.impl.tuple.Tuples;
+import kafka.admin.AdminUtils;
+import kafka.producer.KeyedMessage;
+import kafka.producer.Producer;
+import kafka.producer.ProducerConfig;
+import kafka.serializer.StringEncoder;
+import kafka.utils.TestUtils;
+import org.junit.After;
+import scala.collection.JavaConversions;
+import scala.collection.Map;
+import scala.collection.immutable.List$;
+import scala.collection.immutable.Map$;
+import scala.collection.immutable.Seq;
+
+import org.springframework.integration.kafka.core.KafkaBrokerConnectionFactory;
+import org.springframework.integration.kafka.core.KafkaConfiguration;
+
+/**
+ * @author Marius Bogoevici
+ */
+public abstract class AbstractBrokerTest {
+
+	public static final String TEST_TOPIC = "test-topic";
+
+	public abstract KafkaEmbeddedBrokerRule getKafkaRule();
+
+	@After
+	public void cleanUpTopic() {
+		AdminUtils.deleteTopic(getKafkaRule().getZookeeperClient(), TEST_TOPIC);
+		TestUtils.waitUntilMetadataIsPropagated(asScalaBuffer(getKafkaRule().getKafkaServers()), TEST_TOPIC, 0, 5000L);
+	}
+
+	public void createTopic(String topicName, int partitionCount, int brokers, int replication) {
+		MutableMultimap<Integer, Integer> partitionDistribution = createPartitionDistribution(partitionCount, brokers, replication);
+		AdminUtils.createOrUpdateTopicPartitionAssignmentPathInZK(getKafkaRule().getZookeeperClient(), topicName, toKafkaPartitionMap(partitionDistribution), AdminUtils.createOrUpdateTopicPartitionAssignmentPathInZK$default$4(), AdminUtils.createOrUpdateTopicPartitionAssignmentPathInZK$default$5());
+		for (int i = 0; i < partitionDistribution.keysView().size(); i++) {
+			TestUtils.waitUntilMetadataIsPropagated(asScalaBuffer(getKafkaRule().getKafkaServers()), TEST_TOPIC, i, 5000L);
+		}
+	}
+
+	public MutableMultimap<Integer, Integer> createPartitionDistribution(int partitionCount, int brokers, int replication) {
+		MutableMultimap<Integer, Integer> partitionDistribution = Multimaps.mutable.list.with();
+		for (int i = 0; i < partitionCount; i++) {
+			for (int j = 0; j < replication; j++) {
+				partitionDistribution.put(i, (i + j) % brokers);
+			}
+		}
+		return partitionDistribution;
+	}
+
+
+	public KafkaConfiguration getKafkaConfiguration() {
+		return new KafkaConfiguration(getKafkaRule().getBrokerAddresses());
+	}
+
+	public static scala.collection.Seq<KeyedMessage<String, String>> createMessages(int count) {
+		List<KeyedMessage<String,String>> messages = new ArrayList<KeyedMessage<String, String>>();
+		for (int i=0; i<count; i++) {
+			messages.add(new KeyedMessage<String, String>(TEST_TOPIC, "Key " + i, i, "Message " + i));
+		}
+		return asScalaBuffer(messages).toSeq();
+	}
+
+	public Producer<String, String> createStringProducer(int compression) {
+		Properties producerConfig = TestUtils.getProducerConfig(getKafkaRule().getBrokersAsString(), TestPartitioner.class.getCanonicalName());
+		producerConfig.put("serializer.class", StringEncoder.class.getCanonicalName());
+		producerConfig.put("key.serializer.class",  StringEncoder.class.getCanonicalName());
+		producerConfig.put("compression.codec",  Integer.toString(compression));
+		return new Producer<String, String>(new ProducerConfig(producerConfig));
+	}
+
+	public KafkaBrokerConnectionFactory getKafkaBrokerConnectionFactory() throws Exception {
+		KafkaBrokerConnectionFactory kafkaBrokerConnectionFactory = new KafkaBrokerConnectionFactory(getKafkaConfiguration());
+		kafkaBrokerConnectionFactory.afterPropertiesSet();
+		return kafkaBrokerConnectionFactory;
+	}
+
+	private Map toKafkaPartitionMap(Multimap<Integer, Integer> partitions) {
+		java.util.Map<Object, Seq<Object>> m = partitions.toMap().collect(new Function2<Integer, RichIterable<Integer>, Pair<Object, Seq<Object>>>() {
+			@Override
+			public Pair<Object, Seq<Object>> value(Integer argument1, RichIterable<Integer> argument2) {
+				return Tuples.pair((Object) argument1, List$.MODULE$.fromArray(argument2.toArray(new Object[0])).toSeq());
+			}
+		});
+		return Map$.MODULE$.apply(JavaConversions.asScalaMap(m).toSeq());
+	}
+
+
+}

--- a/src/test/java/org/springframework/integration/kafka/listener/AbstractMessageListenerContainerTest.java
+++ b/src/test/java/org/springframework/integration/kafka/listener/AbstractMessageListenerContainerTest.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.springframework.integration.kafka.listener;
+
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
+import static org.hamcrest.core.IsCollectionContaining.hasItem;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.springframework.integration.kafka.util.MessageUtils.decodeKey;
+import static org.springframework.integration.kafka.util.MessageUtils.decodePayload;
+
+import java.util.ArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import com.gs.collections.api.RichIterable;
+import com.gs.collections.api.bag.MutableBag;
+import com.gs.collections.api.block.function.Function;
+import com.gs.collections.api.block.function.Function2;
+import com.gs.collections.api.block.procedure.Procedure;
+import com.gs.collections.api.list.MutableList;
+import com.gs.collections.api.map.MutableMap;
+import com.gs.collections.api.multimap.list.MutableListMultimap;
+import com.gs.collections.api.set.MutableSet;
+import com.gs.collections.api.tuple.Pair;
+import com.gs.collections.impl.factory.Sets;
+import com.gs.collections.impl.multimap.list.SynchronizedPutFastListMultimap;
+import com.gs.collections.impl.tuple.Tuples;
+import kafka.serializer.StringDecoder;
+import kafka.utils.VerifiableProperties;
+import org.hamcrest.Matchers;
+
+import org.springframework.integration.kafka.core.KafkaBrokerConnectionFactory;
+import org.springframework.integration.kafka.core.Partition;
+import org.springframework.integration.kafka.core.KafkaMessage;
+import org.springframework.integration.kafka.listener.KafkaMessageListenerContainer;
+import org.springframework.integration.kafka.listener.MessageListener;
+
+/**
+ * @author Marius Bogoevici
+ */
+public abstract class AbstractMessageListenerContainerTest extends AbstractBrokerTest {
+
+	public void runMessageListenerTest(int maxReceiveSize, int concurrency, int partitionCount, int testMessageCount, int divisionFactor, int compressionCodec) throws Exception {
+
+		KafkaBrokerConnectionFactory kafkaBrokerConnectionFactory = getKafkaBrokerConnectionFactory();
+		ArrayList<Partition> readPartitions = new ArrayList<Partition>();
+		for (int i = 0; i < partitionCount; i++) {
+			if(i % divisionFactor == 0) {
+				readPartitions.add(new Partition(TEST_TOPIC, i));
+			}
+		}
+		final KafkaMessageListenerContainer kafkaMessageListenerContainer = new KafkaMessageListenerContainer(kafkaBrokerConnectionFactory, readPartitions.toArray(new Partition[readPartitions.size()]));
+		kafkaMessageListenerContainer.setMaxSize(maxReceiveSize);
+		kafkaMessageListenerContainer.setConcurrency(concurrency);
+
+		int expectedMessageCount = testMessageCount / divisionFactor;
+
+		final MutableListMultimap<Integer,KeyedMessageWithOffset> receivedData = new SynchronizedPutFastListMultimap<Integer, KeyedMessageWithOffset>();
+		final CountDownLatch latch = new CountDownLatch(expectedMessageCount);
+		kafkaMessageListenerContainer.setMessageListener(new MessageListener() {
+			@Override
+			public void onMessage(KafkaMessage message) {
+				StringDecoder decoder = new StringDecoder(new VerifiableProperties());
+				receivedData.put(message.getMetadata().getPartition().getId(),new KeyedMessageWithOffset(decodeKey(message, decoder), decodePayload(message, decoder), message.getMetadata().getOffset(), Thread.currentThread().getName(), message.getMetadata().getPartition().getId()));
+				latch.countDown();
+			}
+		});
+
+		kafkaMessageListenerContainer.start();
+
+		createStringProducer(compressionCodec).send(createMessages(testMessageCount));
+
+		latch.await((expectedMessageCount/5000) + 1, TimeUnit.MINUTES);
+		kafkaMessageListenerContainer.stop();
+
+		assertThat(receivedData.valuesView().toList(), hasSize(expectedMessageCount));
+		assertThat(latch.getCount(), equalTo(0L));
+		System.out.println("All messages received ... checking ");
+
+		validateMessageReceipt(receivedData, concurrency, partitionCount, testMessageCount, expectedMessageCount, readPartitions, divisionFactor);
+
+	}
+
+	public void validateMessageReceipt(MutableListMultimap<Integer, KeyedMessageWithOffset> receivedData, int concurrency, int partitionCount, int testMessageCount, int expectedMessageCount, ArrayList<Partition> readPartitions, int divisionFactor) {
+		// Group messages received by processing thread
+		MutableListMultimap<String, KeyedMessageWithOffset> messagesByThread = receivedData.valuesView().toList().groupBy(new Function<KeyedMessageWithOffset, String>() {
+			@Override
+			public String valueOf(KeyedMessageWithOffset object) {
+				return object.getThreadName();
+			}
+		});
+
+		// Execution has taken place on as many distinct threads as configured
+		assertThat(messagesByThread.keysView().size(), Matchers.equalTo(concurrency));
+
+		// Group partitions by thread
+		MutableMap<String, MutableSet<Integer>> partitionsByThread = messagesByThread.toMap().collect(new Function2<String, RichIterable<KeyedMessageWithOffset>, Pair<String, MutableSet<Integer>>>() {
+			@Override
+			public Pair<String, MutableSet<Integer>> value(String argument1, RichIterable<KeyedMessageWithOffset> argument2) {
+				return Tuples.pair(argument1, argument2.collect(new Function<KeyedMessageWithOffset, Integer>() {
+					@Override
+					public Integer valueOf(KeyedMessageWithOffset object) {
+						return object.getPartition();
+					}
+				}).toSet());
+			}
+		});
+
+		// Messages from a partition have been executed on the same thread and groups are mutually exclusive
+		final MutableSet<Integer> validatedPartitions = Sets.mutable.of();
+		partitionsByThread.valuesView().forEach(new Procedure<MutableSet<Integer>>() {
+			@Override
+			public void value(MutableSet<Integer> partitions) {
+				assertThat(validatedPartitions.intersect(partitions), empty());
+				validatedPartitions.addAll(partitions);
+			}
+		});
+
+		// All partitions are accounted for, but only the ones that we were expecting to read from
+		for (int i = 0; i < partitionCount; i++) {
+			if (i % divisionFactor == 0) {
+				assertThat(validatedPartitions, hasItem(i));
+			} else {
+				assertThat(validatedPartitions, not(hasItem(i)));
+			}
+		}
+
+		// Sort data by payload in order to identify duplicates
+		MutableList<String> sortedPayloads = receivedData.valuesView().toList().collect(new Function<KeyedMessageWithOffset, String>() {
+			@Override
+			public String valueOf(KeyedMessageWithOffset object) {
+				return object.getPayload();
+			}
+		}).sortThis();
+
+		// Remove unique values - what is left are duplicates
+		MutableBag<String> duplicates = sortedPayloads.toBag();
+		duplicates.removeAll(sortedPayloads.toSet());
+
+		// The final set has exactly the same size as the message count
+		assertThat(sortedPayloads, hasSize(expectedMessageCount));
+
+		// There are no duplicates - all messages have been received only once
+		assertThat(duplicates, hasSize(0));
+
+		// Group offsets by partition
+		MutableMap<Integer, MutableList<Long>> offsetsByPartition = receivedData.toMap().collect(new Function2<Integer, RichIterable<KeyedMessageWithOffset>, Pair<Integer, MutableList<Long>>>() {
+			@Override
+			public Pair<Integer, MutableList<Long>> value(Integer partition, RichIterable<KeyedMessageWithOffset> argument2) {
+				return Tuples.pair(partition, argument2.collect(new Function<KeyedMessageWithOffset, Long>() {
+					@Override
+					public Long valueOf(KeyedMessageWithOffset object) {
+						return object.getOffset();
+					}
+				}).toList());
+			}
+		});
+
+		// Check that the sequence of offsets has been processed in ascending order, with no gaps
+		for (MutableList<Long> offsetsForPartition : offsetsByPartition.valuesView()) {
+			for (int i = 0; i < offsetsForPartition.size() - 1; i++) {
+				assertThat(offsetsForPartition.get(i+1), equalTo(offsetsForPartition.get(i) + 1));
+			}
+		}
+	}
+
+	static class KeyedMessageWithOffset {
+
+		String key;
+
+		String payload;
+
+		Long offset;
+
+		String threadName;
+
+		int partition;
+
+		public KeyedMessageWithOffset(String key, String payload, Long offset, String threadName, int partition) {
+			this.key = key;
+			this.payload = payload;
+			this.offset = offset;
+			this.threadName = threadName;
+			this.partition = partition;
+		}
+
+		public String getKey() {
+			return key;
+		}
+
+		public String getPayload() {
+			return payload;
+		}
+
+		public Long getOffset() {
+			return offset;
+		}
+
+		public String getThreadName() {
+			return threadName;
+		}
+
+		public int getPartition() {
+			return partition;
+		}
+	}
+}

--- a/src/test/java/org/springframework/integration/kafka/listener/ChannelSendingMessageListener.java
+++ b/src/test/java/org/springframework/integration/kafka/listener/ChannelSendingMessageListener.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.springframework.integration.kafka.listener;
+
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.integration.kafka.core.KafkaMessage;
+import org.springframework.integration.kafka.listener.MessageListener;
+import org.springframework.integration.support.MessageBuilder;
+import org.springframework.integration.support.channel.BeanFactoryChannelResolver;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.core.DestinationResolver;
+
+/**
+ * @author Marius Bogoevici
+ */
+public class ChannelSendingMessageListener implements MessageListener, ApplicationContextAware {
+
+	private String channelName;
+
+	private MessageChannel messageChannel;
+
+	public String getChannelName() {
+		return channelName;
+	}
+
+	public void setChannelName(String channelName) {
+		this.channelName = channelName;
+	}
+
+	DestinationResolver<MessageChannel> destinationResolver;
+
+	@Override
+	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+		this.destinationResolver = new BeanFactoryChannelResolver(applicationContext);
+		messageChannel = destinationResolver.resolveDestination(channelName);
+	}
+
+	@Override
+	public void onMessage(KafkaMessage message) {
+		byte b[] = new byte[message.getMessage().payloadSize()];
+		message.getMessage().payload().get(b);
+		messageChannel.send(MessageBuilder.withPayload(new String(b)).build());
+		System.out.println("Received " + new String(b) + " from partition " + message.getMetadata().getPartition());
+	}
+}

--- a/src/test/java/org/springframework/integration/kafka/listener/KafkaEmbeddedBrokerRule.java
+++ b/src/test/java/org/springframework/integration/kafka/listener/KafkaEmbeddedBrokerRule.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.springframework.integration.kafka.listener;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+import com.gs.collections.api.block.function.Function;
+import com.gs.collections.impl.list.mutable.FastList;
+import com.gs.collections.impl.utility.ListIterate;
+import kafka.server.KafkaConfig;
+import kafka.server.KafkaServer;
+import kafka.utils.SystemTime$;
+import kafka.utils.TestUtils;
+import kafka.utils.TestZKUtils;
+import kafka.utils.Utils;
+import kafka.utils.ZKStringSerializer$;
+import kafka.zk.EmbeddedZookeeper;
+import org.I0Itec.zkclient.ZkClient;
+import org.I0Itec.zkclient.exception.ZkInterruptedException;
+import org.junit.rules.ExternalResource;
+import scala.collection.JavaConversions;
+
+import org.springframework.integration.kafka.core.KafkaBrokerAddress;
+
+/**
+ * @author Marius Bogoevici
+ */
+public class KafkaEmbeddedBrokerRule extends ExternalResource {
+
+	private int count;
+
+	private boolean controlledShutdown;
+
+	private List<Integer> kafkaPorts;
+
+	private List<KafkaServer> kafkaServers;
+
+	private EmbeddedZookeeper zookeeper;
+
+	private ZkClient zookeeperClient;
+
+	@SuppressWarnings("unchecked")
+	public KafkaEmbeddedBrokerRule(int count, boolean controlledShutdown) {
+		this.count = count;
+		this.controlledShutdown = controlledShutdown;
+		this.kafkaPorts = JavaConversions.asJavaList((scala.collection.immutable.List) TestUtils.choosePorts(count));
+	}
+
+	public KafkaEmbeddedBrokerRule(int count) {
+		this(count, false);
+	}
+
+	@Override
+	protected void before() throws Throwable {
+		zookeeper = new EmbeddedZookeeper(TestZKUtils.zookeeperConnect());
+		int zkConnectionTimeout = 6000;
+		int zkSessionTimeout = 6000;
+		zookeeperClient = new ZkClient(TestZKUtils.zookeeperConnect(), zkSessionTimeout, zkConnectionTimeout, ZKStringSerializer$.MODULE$);
+		kafkaServers = new ArrayList<KafkaServer>();
+		for (int i = 0; i < count; i++) {
+			Properties brokerConfigProperties = TestUtils.createBrokerConfig(i, kafkaPorts.get(i));
+			brokerConfigProperties.put("controlled.shutdown.enable", Boolean.toString(controlledShutdown));
+			KafkaServer server = TestUtils.createServer(new KafkaConfig(brokerConfigProperties), SystemTime$.MODULE$);
+			kafkaServers.add(server);
+		}
+	}
+
+	@Override
+	protected void after() {
+		for (KafkaServer kafkaServer : kafkaServers) {
+			try {
+				kafkaServer.shutdown();
+			}
+			catch (Exception e) {
+				// do nothing
+			}
+			try {
+				Utils.rm(kafkaServer.config().logDirs());
+			}
+			catch (Exception e) {
+				// do nothing
+			}
+		}
+		try {
+			zookeeperClient.close();
+		}
+		catch (ZkInterruptedException e) {
+			// do nothing
+		}
+		try {
+			zookeeper.shutdown();
+		}
+		catch (Exception e) {
+			// do nothing
+		}
+	}
+
+	public List<KafkaServer> getKafkaServers() {
+		return kafkaServers;
+	}
+
+	public KafkaServer getKafkaServer(int id) {
+		return kafkaServers.get(id);
+	}
+
+	public EmbeddedZookeeper getZookeeper() {
+		return zookeeper;
+	}
+
+	public ZkClient getZookeeperClient() {
+		return zookeeperClient;
+	}
+
+	public List<KafkaBrokerAddress> getBrokerAddresses() {
+		return ListIterate.collect(kafkaServers, new Function<KafkaServer, KafkaBrokerAddress>() {
+			@Override
+			public KafkaBrokerAddress valueOf(KafkaServer kafkaServer) {
+				return new KafkaBrokerAddress(kafkaServer.config().hostName(), kafkaServer.config().port());
+			}
+		});
+	}
+
+	public void bounce(KafkaBrokerAddress kafkaBrokerAddress) {
+		for (KafkaServer kafkaServer : getKafkaServers()) {
+			if (kafkaBrokerAddress.equals(new KafkaBrokerAddress(kafkaServer.config().hostName(), kafkaServer.config().port()))) {
+				kafkaServer.shutdown();
+			}
+		}
+	}
+
+	public String getBrokersAsString() {
+		return FastList.newList(getBrokerAddresses()).collect(new Function<KafkaBrokerAddress, String>() {
+			@Override
+			public String valueOf(KafkaBrokerAddress object) {
+				return object.getHost() + ":" + object.getPort();
+			}
+		}).makeString(",");
+	}
+}

--- a/src/test/java/org/springframework/integration/kafka/listener/SimpleLogger.java
+++ b/src/test/java/org/springframework/integration/kafka/listener/SimpleLogger.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.springframework.integration.kafka.listener;
+
+import org.springframework.messaging.Message;
+
+/**
+ * @author Marius Bogoevici
+ */
+public class SimpleLogger {
+
+	public void log(Message<?> message) {
+		//System.out.println(message.toString());
+	}
+}

--- a/src/test/java/org/springframework/integration/kafka/listener/TestChannelAdapterWithXmlConfiguration.java
+++ b/src/test/java/org/springframework/integration/kafka/listener/TestChannelAdapterWithXmlConfiguration.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.springframework.integration.kafka.listener;
+
+import static org.hamcrest.Matchers.notNullValue;
+
+import com.gs.collections.api.map.MutableMap;
+import com.gs.collections.impl.factory.Maps;
+import kafka.message.NoCompressionCodec$;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.integration.channel.QueueChannel;
+import org.springframework.messaging.Message;
+
+/**
+ * @author Marius Bogoevici
+ */
+public class TestChannelAdapterWithXmlConfiguration extends AbstractMessageListenerContainerTest {
+
+	@Rule
+	public final KafkaEmbeddedBrokerRule kafkaEmbeddedBrokerRule = new KafkaEmbeddedBrokerRule(1);
+
+
+	@Override
+	public KafkaEmbeddedBrokerRule getKafkaRule() {
+		return this.kafkaEmbeddedBrokerRule;
+	}
+
+
+	@Test
+	public void testConsumptionWithXmlConfiguration() throws Exception {
+
+		createTopic(TEST_TOPIC,1,1,1);
+
+		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(new String[]{"classpath:kafka-integration-no-namespace.xml"}, false);
+
+		createStringProducer(NoCompressionCodec$.MODULE$.codec()).send(createMessages(100));
+
+		MutableMap<String, Object> testProperties = Maps.mutable
+				.with("kafka.test.port", (Object) Integer.toString(kafkaEmbeddedBrokerRule.getBrokerAddresses().get(0).getPort()))
+				.withKeyValue("kafka.test.topic", TEST_TOPIC);
+		context.getEnvironment().getPropertySources()
+						.addFirst(new MapPropertySource("test", testProperties));
+
+		context.refresh();
+
+		QueueChannel output = context.getBean("output", QueueChannel.class);
+
+		for (int i = 0; i < 100; i++) {
+			Message<?> received = output.receive(1000);
+			Assert.assertThat(received, notNullValue());
+			System.out.println(received.getPayload());
+		}
+	}
+}

--- a/src/test/java/org/springframework/integration/kafka/listener/TestKafkaBrokerConnection.java
+++ b/src/test/java/org/springframework/integration/kafka/listener/TestKafkaBrokerConnection.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.springframework.integration.kafka.listener;
+
+import junit.framework.Assert;
+import kafka.producer.Producer;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.springframework.integration.kafka.serializer.common.StringDecoder;
+import org.springframework.integration.kafka.core.KafkaBrokerConnection;
+import org.springframework.integration.kafka.core.KafkaResult;
+import org.springframework.integration.kafka.core.Partition;
+import org.springframework.integration.kafka.core.KafkaMessage;
+import org.springframework.integration.kafka.core.KafkaMessageBatch;
+import org.springframework.integration.kafka.core.KafkaMessageFetchRequest;
+import org.springframework.integration.kafka.util.MessageUtils;
+
+/**
+ * @author Marius Bogoevici
+ */
+public class TestKafkaBrokerConnection extends AbstractBrokerTest {
+
+	@Rule
+	public KafkaEmbeddedBrokerRule kafkaEmbeddedBrokerRule = new KafkaEmbeddedBrokerRule(1);
+
+	@Override
+	public KafkaEmbeddedBrokerRule getKafkaRule() {
+		return kafkaEmbeddedBrokerRule;
+	}
+
+	@Test
+	public void testFetchPartitionMetadata() throws Exception {
+		createTopic(TEST_TOPIC, 1, 1, 1);
+		KafkaBrokerConnection brokerConnection = new KafkaBrokerConnection(getKafkaRule().getBrokerAddresses().get(0));
+		Partition partition = new Partition(TEST_TOPIC, 0);
+		KafkaResult<Long> result = brokerConnection.fetchInitialOffset(-1, partition);
+		Assert.assertEquals(0, result.getErrors().size());
+		Assert.assertEquals(1, result.getResults().size());
+		Assert.assertEquals(Long.valueOf(0), result.getResults().get(partition));
+	}
+
+	@Test
+	public void testReceiveMessages() throws Exception {
+		createTopic(TEST_TOPIC, 1, 1, 1);
+		Producer<String, String> producer = createStringProducer(0);
+		producer.send( createMessages(10));
+		KafkaBrokerConnection brokerConnection = new KafkaBrokerConnection(getKafkaRule().getBrokerAddresses().get(0));
+		Partition partition = new Partition(TEST_TOPIC, 0);
+		KafkaMessageFetchRequest kafkaMessageFetchRequest = new KafkaMessageFetchRequest(partition, 0L, 1000);
+		KafkaResult<KafkaMessageBatch> result = brokerConnection.fetch(kafkaMessageFetchRequest);
+		Assert.assertEquals(0, result.getErrors().size());
+		Assert.assertEquals(1, result.getResults().size());
+		Assert.assertEquals(10, result.getResults().get(partition).getMessages().size());
+		Assert.assertEquals(10,result.getResults().get(partition).getHighWatermark());
+		StringDecoder decoder = new StringDecoder();
+		int i = 0;
+		for (KafkaMessage kafkaMessage : result.getResults().get(partition).getMessages()) {
+			Assert.assertEquals("Key " + i, MessageUtils.decodeKey(kafkaMessage, decoder));
+			Assert.assertEquals("Message " + i, MessageUtils.decodePayload(kafkaMessage, decoder));
+			i++;
+		}
+	}
+
+	@Test
+	public void testReceiveMessagesWithCompression1() throws Exception {
+		createTopic(TEST_TOPIC, 1, 1, 1);
+		Producer<String, String> producer = createStringProducer(1);
+		producer.send( createMessages(10));
+		KafkaBrokerConnection brokerConnection = new KafkaBrokerConnection(getKafkaRule().getBrokerAddresses().get(0));
+		Partition partition = new Partition(TEST_TOPIC, 0);
+		KafkaMessageFetchRequest kafkaMessageFetchRequest = new KafkaMessageFetchRequest(partition, 0L, 1000);
+		KafkaResult<KafkaMessageBatch> result = brokerConnection.fetch(kafkaMessageFetchRequest);
+		Assert.assertEquals(0, result.getErrors().size());
+		Assert.assertEquals(1, result.getResults().size());
+		Assert.assertEquals(10, result.getResults().get(partition).getMessages().size());
+		Assert.assertEquals(10,result.getResults().get(partition).getHighWatermark());
+		StringDecoder decoder = new StringDecoder();
+		int i = 0;
+		for (KafkaMessage kafkaMessage : result.getResults().get(partition).getMessages()) {
+			Assert.assertEquals("Key " + i, MessageUtils.decodeKey(kafkaMessage, decoder));
+			Assert.assertEquals("Message " + i, MessageUtils.decodePayload(kafkaMessage, decoder));
+			i++;
+		}
+	}
+
+	@Test
+	public void testReceiveMessagesWithCompression2() throws Exception {
+		createTopic(TEST_TOPIC, 1, 1, 1);
+		Producer<String, String> producer = createStringProducer(2);
+		producer.send( createMessages(10));
+		KafkaBrokerConnection brokerConnection = new KafkaBrokerConnection(getKafkaRule().getBrokerAddresses().get(0));
+		Partition partition = new Partition(TEST_TOPIC, 0);
+		KafkaMessageFetchRequest kafkaMessageFetchRequest = new KafkaMessageFetchRequest(partition, 0L, 1000);
+		KafkaResult<KafkaMessageBatch> result = brokerConnection.fetch(kafkaMessageFetchRequest);
+		Assert.assertEquals(0, result.getErrors().size());
+		Assert.assertEquals(1, result.getResults().size());
+		Assert.assertEquals(10, result.getResults().get(partition).getMessages().size());
+		Assert.assertEquals(10,result.getResults().get(partition).getHighWatermark());
+		StringDecoder decoder = new StringDecoder();
+		int i = 0;
+		for (KafkaMessage kafkaMessage : result.getResults().get(partition).getMessages()) {
+			Assert.assertEquals("Key " + i, MessageUtils.decodeKey(kafkaMessage, decoder));
+			Assert.assertEquals("Message " + i, MessageUtils.decodePayload(kafkaMessage, decoder));
+			i++;
+		}
+	}
+
+}

--- a/src/test/java/org/springframework/integration/kafka/listener/TestKafkaConnectionFactory.java
+++ b/src/test/java/org/springframework/integration/kafka/listener/TestKafkaConnectionFactory.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.springframework.integration.kafka.listener;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
+import static org.junit.Assert.assertThat;
+
+import java.util.List;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.springframework.integration.kafka.core.KafkaBrokerAddress;
+import org.springframework.integration.kafka.core.KafkaBrokerConnection;
+import org.springframework.integration.kafka.core.KafkaBrokerConnectionFactory;
+import org.springframework.integration.kafka.core.KafkaConfiguration;
+import org.springframework.integration.kafka.core.KafkaResult;
+import org.springframework.integration.kafka.core.Partition;
+
+/**
+ * @author Marius Bogoevici
+ */
+public class TestKafkaConnectionFactory extends AbstractBrokerTest {
+
+	@Rule
+	public KafkaEmbeddedBrokerRule kafkaEmbeddedBrokerRule = new KafkaEmbeddedBrokerRule(1);
+
+	@Override
+	public KafkaEmbeddedBrokerRule getKafkaRule() {
+		return kafkaEmbeddedBrokerRule;
+	}
+
+	@Test
+	public void testCreateConnectionFactory() throws Exception {
+
+		createTopic(TEST_TOPIC, 1, 1, 1);
+
+		List<KafkaBrokerAddress> brokerAddresses = getKafkaRule().getBrokerAddresses();
+		Partition partition = new Partition(TEST_TOPIC, 0);
+		KafkaBrokerConnectionFactory kafkaBrokerConnectionFactory = new KafkaBrokerConnectionFactory(new KafkaConfiguration(brokerAddresses));
+		kafkaBrokerConnectionFactory.afterPropertiesSet();
+		KafkaBrokerConnection connection = kafkaBrokerConnectionFactory.createConnection(getKafkaRule().getBrokerAddresses().get(0));
+		KafkaResult<KafkaBrokerAddress> leaders = connection.findLeaders(TEST_TOPIC);
+		assertThat(leaders.getErrors().entrySet(), empty());
+		assertThat(leaders.getResults().entrySet(), hasSize(1));
+		assertThat(leaders.getResults().get(partition), equalTo(getKafkaRule().getBrokerAddresses().get(0)));
+	}
+}

--- a/src/test/java/org/springframework/integration/kafka/listener/TestKafkaInboundChannelAdapter.java
+++ b/src/test/java/org/springframework/integration/kafka/listener/TestKafkaInboundChannelAdapter.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.springframework.integration.kafka.listener;
+
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.springframework.integration.kafka.inbound.KafkaInboundChannelAdapter.KAFKA_MESSAGE_KEY;
+import static org.springframework.integration.kafka.inbound.KafkaInboundChannelAdapter.KAFKA_MESSAGE_OFFSET;
+import static org.springframework.integration.kafka.inbound.KafkaInboundChannelAdapter.KAFKA_MESSAGE_PARTITION;
+
+import java.util.ArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import com.gs.collections.api.multimap.list.MutableListMultimap;
+import com.gs.collections.impl.multimap.list.SynchronizedPutFastListMultimap;
+import kafka.message.NoCompressionCodec$;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.springframework.integration.kafka.core.KafkaBrokerConnectionFactory;
+import org.springframework.integration.kafka.core.Partition;
+import org.springframework.integration.kafka.inbound.KafkaInboundChannelAdapter;
+import org.springframework.integration.kafka.serializer.common.StringDecoder;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+
+/**
+ * @author Marius Bogoevici
+ */
+public class TestKafkaInboundChannelAdapter extends AbstractMessageListenerContainerTest {
+
+	@Rule
+	public final KafkaEmbeddedBrokerRule kafkaEmbeddedBrokerRule = new KafkaEmbeddedBrokerRule(1);
+
+	@Override
+	public KafkaEmbeddedBrokerRule getKafkaRule() {
+		return kafkaEmbeddedBrokerRule;
+	}
+
+	@Test
+	public void testLowVolumeLowConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 5, 1, 1);
+
+		KafkaBrokerConnectionFactory kafkaBrokerConnectionFactory = getKafkaBrokerConnectionFactory();
+		ArrayList<Partition> readPartitions = new ArrayList<Partition>();
+		for (int i = 0; i < 5; i++) {
+			readPartitions.add(new Partition(TEST_TOPIC, i));
+		}
+
+		final KafkaMessageListenerContainer kafkaMessageListenerContainer = new KafkaMessageListenerContainer(kafkaBrokerConnectionFactory, readPartitions.toArray(new Partition[readPartitions.size()]));
+		kafkaMessageListenerContainer.setMaxSize(100);
+		kafkaMessageListenerContainer.setConcurrency(2);
+
+		int expectedMessageCount = 100;
+
+		final MutableListMultimap<Integer,KeyedMessageWithOffset> receivedData = new SynchronizedPutFastListMultimap<Integer, KeyedMessageWithOffset>();
+		final CountDownLatch latch = new CountDownLatch(expectedMessageCount);
+
+		KafkaInboundChannelAdapter kafkaInboundChannelAdapter = new KafkaInboundChannelAdapter(kafkaMessageListenerContainer);
+
+		StringDecoder decoder = new StringDecoder();
+		kafkaInboundChannelAdapter.setKeyDecoder(decoder);
+		kafkaInboundChannelAdapter.setPayloadDecoder(decoder);
+		kafkaInboundChannelAdapter.setOutputChannel(new MessageChannel() {
+			@Override
+			public boolean send(Message<?> message) {
+				latch.countDown();
+				return receivedData.put(
+						(Integer)message.getHeaders().get(KAFKA_MESSAGE_PARTITION),
+						new KeyedMessageWithOffset(
+								(String)message.getHeaders().get(KAFKA_MESSAGE_KEY),
+								(String)message.getPayload(),
+								(Long)message.getHeaders().get(KAFKA_MESSAGE_OFFSET),
+								Thread.currentThread().getName(),
+								(Integer)message.getHeaders().get(KAFKA_MESSAGE_PARTITION)));
+			}
+
+
+			@Override
+			public boolean send(Message<?> message, long timeout) {
+				return send(message);
+			}
+		});
+
+		kafkaInboundChannelAdapter.afterPropertiesSet();
+		kafkaInboundChannelAdapter.start();
+
+		createStringProducer(NoCompressionCodec$.MODULE$.codec()).send(createMessages(100));
+
+		latch.await((expectedMessageCount/5000) + 1, TimeUnit.MINUTES);
+		kafkaMessageListenerContainer.stop();
+
+		assertThat(receivedData.valuesView().toList(), hasSize(expectedMessageCount));
+		assertThat(latch.getCount(), equalTo(0L));
+		System.out.println("All messages received ... checking ");
+
+		validateMessageReceipt(receivedData, 2, 5, 100, expectedMessageCount, readPartitions, 1);
+
+	}
+
+}

--- a/src/test/java/org/springframework/integration/kafka/listener/TestKafkaInboundChannelAdapterWithSpecialOffset.java
+++ b/src/test/java/org/springframework/integration/kafka/listener/TestKafkaInboundChannelAdapterWithSpecialOffset.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.springframework.integration.kafka.listener;
+
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.springframework.integration.kafka.inbound.KafkaInboundChannelAdapter.KAFKA_MESSAGE_KEY;
+import static org.springframework.integration.kafka.inbound.KafkaInboundChannelAdapter.KAFKA_MESSAGE_OFFSET;
+import static org.springframework.integration.kafka.inbound.KafkaInboundChannelAdapter.KAFKA_MESSAGE_PARTITION;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.mail.search.IntegerComparisonTerm;
+
+import com.gs.collections.api.RichIterable;
+import com.gs.collections.api.block.function.Function;
+import com.gs.collections.api.map.MutableMap;
+import com.gs.collections.api.multimap.list.MutableListMultimap;
+import com.gs.collections.api.tuple.Pair;
+import com.gs.collections.impl.block.factory.Functions;
+import com.gs.collections.impl.factory.Maps;
+import com.gs.collections.impl.list.mutable.FastList;
+import com.gs.collections.impl.multimap.list.SynchronizedPutFastListMultimap;
+import com.gs.collections.impl.utility.Iterate;
+import kafka.message.NoCompressionCodec$;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.springframework.integration.kafka.core.KafkaBrokerConnectionFactory;
+import org.springframework.integration.kafka.core.Partition;
+import org.springframework.integration.kafka.inbound.KafkaInboundChannelAdapter;
+import org.springframework.integration.kafka.serializer.common.StringDecoder;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+
+/**
+ * @author Marius Bogoevici
+ */
+public class TestKafkaInboundChannelAdapterWithSpecialOffset extends AbstractMessageListenerContainerTest {
+
+	@Rule
+	public final KafkaEmbeddedBrokerRule kafkaEmbeddedBrokerRule = new KafkaEmbeddedBrokerRule(1);
+
+	@Override
+	public KafkaEmbeddedBrokerRule getKafkaRule() {
+		return kafkaEmbeddedBrokerRule;
+	}
+
+	@Test
+	public void testLowVolumeLowConcurrency() throws Exception {
+
+		// we will send 300 messages: first 200, then another 100
+		// we will start reading from all partitions at offset 100
+		int expectedMessageCount = 200;
+
+		createTopic(TEST_TOPIC, 5, 1, 1);
+
+		KafkaBrokerConnectionFactory kafkaBrokerConnectionFactory = getKafkaBrokerConnectionFactory();
+		ArrayList<Partition> readPartitions = new ArrayList<Partition>();
+		Map<Partition,Long> startingOffsets = new HashMap<Partition, Long>();
+		for (int i = 0; i < 5; i++) {
+			Partition partition = new Partition(TEST_TOPIC, i);
+			readPartitions.add(partition);
+			startingOffsets.put(partition, 20L);
+		}
+
+		final KafkaMessageListenerContainer kafkaMessageListenerContainer = new KafkaMessageListenerContainer(kafkaBrokerConnectionFactory, readPartitions.toArray(new Partition[readPartitions.size()]));
+		kafkaMessageListenerContainer.setMaxSize(100);
+		kafkaMessageListenerContainer.setConcurrency(2);
+		MetadataStoreOffsetManager offsetManager = new MetadataStoreOffsetManager(kafkaBrokerConnectionFactory, startingOffsets);
+		kafkaMessageListenerContainer.setOffsetManager(offsetManager);
+
+		// we send 100 messages
+		createStringProducer(NoCompressionCodec$.MODULE$.codec()).send(createMessagesInRange(0, 199));
+
+		final MutableListMultimap<Integer,KeyedMessageWithOffset> receivedData = new SynchronizedPutFastListMultimap<Integer, KeyedMessageWithOffset>();
+		final CountDownLatch latch = new CountDownLatch(expectedMessageCount);
+
+		KafkaInboundChannelAdapter kafkaInboundChannelAdapter = new KafkaInboundChannelAdapter(kafkaMessageListenerContainer);
+
+		StringDecoder decoder = new StringDecoder();
+		kafkaInboundChannelAdapter.setKeyDecoder(decoder);
+		kafkaInboundChannelAdapter.setPayloadDecoder(decoder);
+		kafkaInboundChannelAdapter.setOutputChannel(new MessageChannel() {
+			@Override
+			public boolean send(Message<?> message) {
+				latch.countDown();
+				return receivedData.put(
+						(Integer)message.getHeaders().get(KAFKA_MESSAGE_PARTITION),
+						new KeyedMessageWithOffset(
+								(String)message.getHeaders().get(KAFKA_MESSAGE_KEY),
+								(String)message.getPayload(),
+								(Long)message.getHeaders().get(KAFKA_MESSAGE_OFFSET),
+								Thread.currentThread().getName(),
+								(Integer)message.getHeaders().get(KAFKA_MESSAGE_PARTITION)));
+			}
+
+
+			@Override
+			public boolean send(Message<?> message, long timeout) {
+				return send(message);
+			}
+		});
+
+		kafkaInboundChannelAdapter.afterPropertiesSet();
+		kafkaInboundChannelAdapter.start();
+
+		createStringProducer(NoCompressionCodec$.MODULE$.codec()).send(createMessagesInRange(200, 299));
+
+		latch.await((expectedMessageCount/5000) + 1, TimeUnit.MINUTES);
+		kafkaMessageListenerContainer.stop();
+
+		assertThat(receivedData.valuesView().toList(), hasSize(expectedMessageCount));
+		assertThat(latch.getCount(), equalTo(0L));
+		System.out.println("All messages received ... checking ");
+
+		validateMessageReceipt(receivedData, 2, 5, 100, expectedMessageCount, readPartitions, 1);
+
+		// For all received messages
+		Collection<KeyedMessageWithOffset> allReceivedMessages = Iterate.flatCollect(receivedData.keyMultiValuePairsView(), new Function<Pair<Integer, RichIterable<KeyedMessageWithOffset>>, RichIterable<KeyedMessageWithOffset>>() {
+			@Override
+			public RichIterable<KeyedMessageWithOffset> valueOf(Pair<Integer, RichIterable<KeyedMessageWithOffset>> object) {
+				return object.getTwo();
+			}
+		});
+
+		// We extract the sequence value, i.e. "Message xx"
+		Integer minValueInMessage = FastList.newList(allReceivedMessages).collect(new Function<KeyedMessageWithOffset, Integer>() {
+			@Override
+			public Integer valueOf(KeyedMessageWithOffset object) {
+				return Integer.parseInt(object.getPayload().split(" ")[1]);
+			}
+		}).min();
+
+		// The lowest received value is 100. That is correct, because messages are evenly distributed across partitions
+		// and we start reading only at partition 200
+		assertThat(minValueInMessage, equalTo(100));
+	}
+
+}

--- a/src/test/java/org/springframework/integration/kafka/listener/TestMultiBroker2.java
+++ b/src/test/java/org/springframework/integration/kafka/listener/TestMultiBroker2.java
@@ -46,7 +46,8 @@ public class TestMultiBroker2 extends AbstractMessageListenerContainerTest {
 		runMessageListenerTest(100, 2, 5, 1000, 1, 0);
 	}
 
-	@Test @Ignore
+	@Test
+	@Ignore
 	public void testHighVolumeLowConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 5, 2, 1);
 		runMessageListenerTest(100, 2, 5, 10000, 1, 0);
@@ -64,7 +65,8 @@ public class TestMultiBroker2 extends AbstractMessageListenerContainerTest {
 		runMessageListenerTest(100, 5, 5, 1000, 1, 0);
 	}
 
-	@Test @Ignore
+	@Test
+	@Ignore
 	public void testHighVolumeMediumConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 5, 2, 1);
 		runMessageListenerTest(100, 5, 5, 100000, 1, 0);
@@ -83,11 +85,11 @@ public class TestMultiBroker2 extends AbstractMessageListenerContainerTest {
 		runMessageListenerTest(100, 20, 100, 10000, 1, 0);
 	}
 
-	@Test @Ignore
+	@Test
+	@Ignore
 	public void testHighVolumeHighConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 100, 2, 1);
 		runMessageListenerTest(100, 20, 100, 100000, 1, 0);
 	}
-
 
 }

--- a/src/test/java/org/springframework/integration/kafka/listener/TestMultiBroker2.java
+++ b/src/test/java/org/springframework/integration/kafka/listener/TestMultiBroker2.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.springframework.integration.kafka.listener;
+
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Marius Bogoevici
+ */
+public class TestMultiBroker2 extends AbstractMessageListenerContainerTest {
+
+	@Rule
+	public KafkaEmbeddedBrokerRule kafkaEmbeddedBrokerRule = new KafkaEmbeddedBrokerRule(2);
+
+	@Override
+	public KafkaEmbeddedBrokerRule getKafkaRule() {
+		return kafkaEmbeddedBrokerRule;
+	}
+
+	@Test
+	public void testLowVolumeLowConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 5, 2, 1);
+		runMessageListenerTest(100, 2, 5, 100, 1, 0);
+	}
+
+	@Test
+	public void testMediumVolumeLowConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 5, 2, 1);
+		runMessageListenerTest(100, 2, 5, 1000, 1, 0);
+	}
+
+	@Test @Ignore
+	public void testHighVolumeLowConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 5, 2, 1);
+		runMessageListenerTest(100, 2, 5, 10000, 1, 0);
+	}
+
+	@Test
+	public void testLowVolumeMediumConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 5, 2, 1);
+		runMessageListenerTest(100, 5, 5, 100, 1, 0);
+	}
+
+	@Test
+	public void testMediumVolumeMediumConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 5, 2, 1);
+		runMessageListenerTest(100, 5, 5, 1000, 1, 0);
+	}
+
+	@Test @Ignore
+	public void testHighVolumeMediumConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 5, 2, 1);
+		runMessageListenerTest(100, 5, 5, 100000, 1, 0);
+	}
+
+
+	@Test
+	public void testLowVolumeHighConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 100, 2, 1);
+		runMessageListenerTest(100, 20, 100, 1000, 1, 0);
+	}
+
+	@Test
+	public void testMediumVolumeHighConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 100, 2, 1);
+		runMessageListenerTest(100, 20, 100, 10000, 1, 0);
+	}
+
+	@Test @Ignore
+	public void testHighVolumeHighConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 100, 2, 1);
+		runMessageListenerTest(100, 20, 100, 100000, 1, 0);
+	}
+
+
+}

--- a/src/test/java/org/springframework/integration/kafka/listener/TestMultiBroker20.java
+++ b/src/test/java/org/springframework/integration/kafka/listener/TestMultiBroker20.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.springframework.integration.kafka.listener;
+
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Marius Bogoevici
+ */
+public class TestMultiBroker20 extends AbstractMessageListenerContainerTest {
+
+	@Rule
+	public final KafkaEmbeddedBrokerRule kafkaEmbeddedBrokerRule = new KafkaEmbeddedBrokerRule(20);
+
+	@Override
+	public KafkaEmbeddedBrokerRule getKafkaRule() {
+		return kafkaEmbeddedBrokerRule;
+	}
+
+	@Test
+	public void testLowVolumeHighConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 100, 20, 1);
+		runMessageListenerTest(100, 20, 100, 1000, 1, 0);
+	}
+
+	@Test
+	public void testMediumVolumeHighConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 100, 20, 1);
+		runMessageListenerTest(100, 20, 100, 10000, 1, 0);
+	}
+
+	@Test @Ignore
+	public void testHighVolumeHighConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 100, 20, 1);
+		runMessageListenerTest(100, 20, 100, 100000, 1, 0);
+	}
+
+
+}

--- a/src/test/java/org/springframework/integration/kafka/listener/TestMultiBroker20.java
+++ b/src/test/java/org/springframework/integration/kafka/listener/TestMultiBroker20.java
@@ -46,11 +46,11 @@ public class TestMultiBroker20 extends AbstractMessageListenerContainerTest {
 		runMessageListenerTest(100, 20, 100, 10000, 1, 0);
 	}
 
-	@Test @Ignore
+	@Test
+	@Ignore
 	public void testHighVolumeHighConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 100, 20, 1);
 		runMessageListenerTest(100, 20, 100, 100000, 1, 0);
 	}
-
 
 }

--- a/src/test/java/org/springframework/integration/kafka/listener/TestMultiBroker5.java
+++ b/src/test/java/org/springframework/integration/kafka/listener/TestMultiBroker5.java
@@ -46,7 +46,8 @@ public class TestMultiBroker5 extends AbstractMessageListenerContainerTest {
 		runMessageListenerTest(100, 2, 5, 1000, 1, 0);
 	}
 
-	@Test @Ignore
+	@Test
+	@Ignore
 	public void testHighVolumeLowConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 5, 5, 1);
 		runMessageListenerTest(100, 2, 5, 10000, 1, 0);
@@ -64,7 +65,8 @@ public class TestMultiBroker5 extends AbstractMessageListenerContainerTest {
 		runMessageListenerTest(100, 5, 5, 1000, 1, 0);
 	}
 
-	@Test @Ignore
+	@Test
+	@Ignore
 	public void testHighVolumeMediumConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 5, 5, 1);
 		runMessageListenerTest(100, 5, 5, 100000, 1, 0);
@@ -83,11 +85,11 @@ public class TestMultiBroker5 extends AbstractMessageListenerContainerTest {
 		runMessageListenerTest(100, 20, 100, 10000, 1, 0);
 	}
 
-	@Test @Ignore
+	@Test
+	@Ignore
 	public void testHighVolumeHighConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 100, 5, 1);
 		runMessageListenerTest(100, 20, 100, 100000, 1, 0);
 	}
-
 
 }

--- a/src/test/java/org/springframework/integration/kafka/listener/TestMultiBroker5.java
+++ b/src/test/java/org/springframework/integration/kafka/listener/TestMultiBroker5.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.springframework.integration.kafka.listener;
+
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Marius Bogoevici
+ */
+public class TestMultiBroker5 extends AbstractMessageListenerContainerTest {
+
+	@Rule
+	public KafkaEmbeddedBrokerRule kafkaEmbeddedBrokerRule = new KafkaEmbeddedBrokerRule(5);
+
+	@Override
+	public KafkaEmbeddedBrokerRule getKafkaRule() {
+		return kafkaEmbeddedBrokerRule;
+	}
+
+	@Test
+	public void testLowVolumeLowConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 5, 5, 1);
+		runMessageListenerTest(100, 2, 5, 100, 1, 0);
+	}
+
+	@Test
+	public void testMediumVolumeLowConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 5, 5, 1);
+		runMessageListenerTest(100, 2, 5, 1000, 1, 0);
+	}
+
+	@Test @Ignore
+	public void testHighVolumeLowConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 5, 5, 1);
+		runMessageListenerTest(100, 2, 5, 10000, 1, 0);
+	}
+
+	@Test
+	public void testLowVolumeMediumConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 5, 5, 1);
+		runMessageListenerTest(100, 5, 5, 100, 1, 0);
+	}
+
+	@Test
+	public void testMediumVolumeMediumConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 5, 5, 1);
+		runMessageListenerTest(100, 5, 5, 1000, 1, 0);
+	}
+
+	@Test @Ignore
+	public void testHighVolumeMediumConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 5, 5, 1);
+		runMessageListenerTest(100, 5, 5, 100000, 1, 0);
+	}
+
+
+	@Test
+	public void testLowVolumeHighConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 100, 5, 1);
+		runMessageListenerTest(100, 20, 100, 1000, 1, 0);
+	}
+
+	@Test
+	public void testMediumVolumeHighConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 100, 5, 1);
+		runMessageListenerTest(100, 20, 100, 10000, 1, 0);
+	}
+
+	@Test @Ignore
+	public void testHighVolumeHighConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 100, 5, 1);
+		runMessageListenerTest(100, 20, 100, 100000, 1, 0);
+	}
+
+
+}

--- a/src/test/java/org/springframework/integration/kafka/listener/TestMultiBroker5Replicated.java
+++ b/src/test/java/org/springframework/integration/kafka/listener/TestMultiBroker5Replicated.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.springframework.integration.kafka.listener;
+
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Marius Bogoevici
+ */
+@Ignore
+public class TestMultiBroker5Replicated extends AbstractMessageListenerContainerTest {
+
+	@Rule
+	public KafkaEmbeddedBrokerRule kafkaEmbeddedBrokerRule = new KafkaEmbeddedBrokerRule(5);
+
+	@Override
+	public KafkaEmbeddedBrokerRule getKafkaRule() {
+		return kafkaEmbeddedBrokerRule;
+	}
+
+	@Test
+	public void testLowVolumeLowConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 5, 5, 3);
+		runMessageListenerTest(100, 2, 5, 100, 1, 0);
+	}
+
+	@Test
+	public void testMediumVolumeLowConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 5, 5, 3);
+		runMessageListenerTest(100, 2, 5, 1000, 1, 0);
+	}
+
+	@Test @Ignore
+	public void testHighVolumeLowConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 5, 5, 3);
+		runMessageListenerTest(100, 2, 5, 10000, 1, 0);
+	}
+
+	@Test
+	public void testLowVolumeMediumConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 5, 5, 3);
+		runMessageListenerTest(100, 5, 5, 100, 1, 0);
+	}
+
+	@Test
+	public void testMediumVolumeMediumConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 5, 5, 3);
+		runMessageListenerTest(100, 5, 5, 1000, 1, 0);
+	}
+
+	@Test @Ignore
+	public void testHighVolumeMediumConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 5, 5, 1);
+		runMessageListenerTest(100, 5, 5, 100000, 1, 0);
+	}
+
+
+	@Test
+	public void testLowVolumeHighConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 100, 5, 3);
+		runMessageListenerTest(100, 20, 100, 1000, 1, 0);
+	}
+
+	@Test
+	public void testMediumVolumeHighConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 100, 5, 3);
+		runMessageListenerTest(100, 20, 100, 10000, 1, 0);
+	}
+
+	@Test @Ignore
+	public void testHighVolumeHighConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 100, 5, 3);
+		runMessageListenerTest(100, 20, 100, 100000, 1, 0);
+	}
+
+
+}

--- a/src/test/java/org/springframework/integration/kafka/listener/TestPartitioner.java
+++ b/src/test/java/org/springframework/integration/kafka/listener/TestPartitioner.java
@@ -33,7 +33,8 @@ public class TestPartitioner implements Partitioner {
 		if (key != null) {
 			if (key instanceof Number) {
 				return ((Number) key).intValue() % numPartitions;
-			} else {
+			}
+			else {
 				try {
 					return Integer.parseInt(key.toString());
 				}
@@ -41,7 +42,8 @@ public class TestPartitioner implements Partitioner {
 					return 0;
 				}
 			}
-		} else {
+		}
+		else {
 			return 0;
 		}
 	}

--- a/src/test/java/org/springframework/integration/kafka/listener/TestPartitioner.java
+++ b/src/test/java/org/springframework/integration/kafka/listener/TestPartitioner.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.springframework.integration.kafka.listener;
+
+import kafka.producer.Partitioner;
+import kafka.utils.VerifiableProperties;
+
+/**
+ * @author Marius Bogoevici
+ */
+public class TestPartitioner implements Partitioner {
+
+	public TestPartitioner(VerifiableProperties properties) {
+	}
+
+	@Override
+	public int partition(Object key, int numPartitions) {
+		if (key != null) {
+			if (key instanceof Number) {
+				return ((Number) key).intValue() % numPartitions;
+			} else {
+				try {
+					return Integer.parseInt(key.toString());
+				}
+				catch (NumberFormatException e) {
+					return 0;
+				}
+			}
+		} else {
+			return 0;
+		}
+	}
+}

--- a/src/test/java/org/springframework/integration/kafka/listener/TestSingleBroker.java
+++ b/src/test/java/org/springframework/integration/kafka/listener/TestSingleBroker.java
@@ -46,7 +46,8 @@ public class TestSingleBroker extends AbstractMessageListenerContainerTest {
 		runMessageListenerTest(100, 2, 5, 1000, 1, 0);
 	}
 
-	@Test @Ignore
+	@Test
+	@Ignore
 	public void testHighVolumeLowConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 5, 1, 1);
 		runMessageListenerTest(100, 2, 5, 10000, 1, 0);
@@ -64,7 +65,8 @@ public class TestSingleBroker extends AbstractMessageListenerContainerTest {
 		runMessageListenerTest(100, 5, 5, 1000, 1, 0);
 	}
 
-	@Test @Ignore
+	@Test
+	@Ignore
 	public void testHighVolumeMediumConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 5, 1, 1);
 		runMessageListenerTest(100, 5, 5, 100000, 1, 0);
@@ -82,11 +84,11 @@ public class TestSingleBroker extends AbstractMessageListenerContainerTest {
 		runMessageListenerTest(100, 20, 100, 10000, 1, 0);
 	}
 
-	@Test @Ignore
+	@Test
+	@Ignore
 	public void testHighVolumeHighConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 100, 1, 1);
 		runMessageListenerTest(100, 20, 100, 100000, 1, 0);
 	}
-
 
 }

--- a/src/test/java/org/springframework/integration/kafka/listener/TestSingleBroker.java
+++ b/src/test/java/org/springframework/integration/kafka/listener/TestSingleBroker.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.springframework.integration.kafka.listener;
+
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Marius Bogoevici
+ */
+public class TestSingleBroker extends AbstractMessageListenerContainerTest {
+
+	@Rule
+	public final KafkaEmbeddedBrokerRule kafkaEmbeddedBrokerRule = new KafkaEmbeddedBrokerRule(1);
+
+	@Override
+	public KafkaEmbeddedBrokerRule getKafkaRule() {
+		return kafkaEmbeddedBrokerRule;
+	}
+
+	@Test
+	public void testLowVolumeLowConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 5, 1, 1);
+		runMessageListenerTest(100, 2, 5, 100, 1, 0);
+	}
+
+	@Test
+	public void testMediumVolumeLowConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 5, 1, 1);
+		runMessageListenerTest(100, 2, 5, 1000, 1, 0);
+	}
+
+	@Test @Ignore
+	public void testHighVolumeLowConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 5, 1, 1);
+		runMessageListenerTest(100, 2, 5, 10000, 1, 0);
+	}
+
+	@Test
+	public void testLowVolumeMediumConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 5, 1, 1);
+		runMessageListenerTest(100, 5, 5, 100, 1, 0);
+	}
+
+	@Test
+	public void testMediumVolumeMediumConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 5, 1, 1);
+		runMessageListenerTest(100, 5, 5, 1000, 1, 0);
+	}
+
+	@Test @Ignore
+	public void testHighVolumeMediumConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 5, 1, 1);
+		runMessageListenerTest(100, 5, 5, 100000, 1, 0);
+	}
+
+	@Test
+	public void testLowVolumeHighConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 100, 1, 1);
+		runMessageListenerTest(100, 20, 100, 1000, 1, 0);
+	}
+
+	@Test
+	public void testMediumVolumeHighConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 100, 1, 1);
+		runMessageListenerTest(100, 20, 100, 10000, 1, 0);
+	}
+
+	@Test @Ignore
+	public void testHighVolumeHighConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 100, 1, 1);
+		runMessageListenerTest(100, 20, 100, 100000, 1, 0);
+	}
+
+
+}

--- a/src/test/java/org/springframework/integration/kafka/listener/TestSingleBrokerWithCompression.java
+++ b/src/test/java/org/springframework/integration/kafka/listener/TestSingleBrokerWithCompression.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.springframework.integration.kafka.listener;
+
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Marius Bogoevici
+ */
+public class TestSingleBrokerWithCompression extends AbstractMessageListenerContainerTest {
+
+	@Rule
+	public final KafkaEmbeddedBrokerRule kafkaEmbeddedBrokerRule = new KafkaEmbeddedBrokerRule(1);
+
+	@Override
+	public KafkaEmbeddedBrokerRule getKafkaRule() {
+		return kafkaEmbeddedBrokerRule;
+	}
+
+	@Test
+	public void testLowVolumeLowConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 5, 1, 1);
+		runMessageListenerTest(10000, 2, 5, 100, 1, 1);
+	}
+
+	@Test
+	public void testMediumVolumeLowConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 5, 1, 1);
+		runMessageListenerTest(10000, 2, 5, 1000, 1, 1);
+	}
+
+	@Test @Ignore
+	public void testHighVolumeLowConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 5, 1, 1);
+		runMessageListenerTest(10000, 2, 5, 10000, 1, 1);
+	}
+
+	@Test
+	public void testLowVolumeMediumConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 5, 1, 1);
+		runMessageListenerTest(10000, 5, 5, 100, 1, 1);
+	}
+
+	@Test
+	public void testMediumVolumeMediumConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 5, 1, 1);
+		runMessageListenerTest(10000, 5, 5, 1000, 1, 1);
+	}
+
+	@Test @Ignore
+	public void testHighVolumeMediumConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 5, 1, 1);
+		runMessageListenerTest(10000, 5, 5, 100000, 1, 1);
+	}
+
+	@Test
+	public void testLowVolumeHighConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 100, 1, 1);
+		runMessageListenerTest(10000, 20, 100, 1000, 1, 1);
+	}
+
+	@Test
+	public void testMediumVolumeHighConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 100, 1, 1);
+		runMessageListenerTest(10000, 20, 100, 10000, 1, 1);
+	}
+
+	@Test @Ignore
+	public void testHighVolumeHighConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 100, 1, 1);
+		runMessageListenerTest(10000, 20, 100, 100000, 1, 1);
+	}
+
+
+}

--- a/src/test/java/org/springframework/integration/kafka/listener/TestSingleBrokerWithPartitionSubset.java
+++ b/src/test/java/org/springframework/integration/kafka/listener/TestSingleBrokerWithPartitionSubset.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.springframework.integration.kafka.listener;
+
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Marius Bogoevici
+ */
+public class TestSingleBrokerWithPartitionSubset extends AbstractMessageListenerContainerTest {
+
+	@Rule
+	public final KafkaEmbeddedBrokerRule kafkaEmbeddedBrokerRule = new KafkaEmbeddedBrokerRule(1);
+
+	@Override
+	public KafkaEmbeddedBrokerRule getKafkaRule() {
+		return kafkaEmbeddedBrokerRule;
+	}
+
+	@Test
+	public void testLowVolumeLowConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 4, 1, 1);
+		runMessageListenerTest(100, 2, 4, 100, 2, 0);
+	}
+
+	@Test
+	public void testMediumVolumeLowConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 4, 1, 1);
+		runMessageListenerTest(100, 2, 4, 1000, 2, 0);
+	}
+
+	@Test @Ignore
+	public void testHighVolumeLowConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 4, 1, 1);
+		runMessageListenerTest(100, 2, 4, 10000, 2, 0);
+	}
+
+	@Test
+	public void testLowVolumeMediumConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 10, 1, 1);
+		runMessageListenerTest(100, 5, 10, 100, 2, 0);
+	}
+
+	@Test
+	public void testMediumVolumeMediumConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 10, 1, 1);
+		runMessageListenerTest(100, 5, 10, 1000, 2, 0);
+	}
+
+	@Test @Ignore
+	public void testHighVolumeMediumConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 10, 1, 1);
+		runMessageListenerTest(100, 5, 10, 100000, 2, 0);
+	}
+
+
+	@Test
+	public void testLowVolumeHighConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 100, 1, 1);
+		runMessageListenerTest(100, 20, 100, 1000, 2, 0);
+	}
+
+	@Test
+	public void testMediumVolumeHighConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 100, 1, 1);
+		runMessageListenerTest(100, 20, 100, 10000, 2, 0);
+	}
+
+	@Test @Ignore
+	public void testHighVolumeHighConcurrency() throws Exception {
+		createTopic(TEST_TOPIC, 100, 1, 1);
+		runMessageListenerTest(100, 20, 100, 100000, 2, 0);
+	}
+
+
+}

--- a/src/test/java/org/springframework/integration/kafka/rule/KafkaRunning.java
+++ b/src/test/java/org/springframework/integration/kafka/rule/KafkaRunning.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.integration.kafka.rule;
 
+import kafka.utils.ZKStringSerializer$;
+import kafka.utils.ZkUtils;
 import org.I0Itec.zkclient.ZkClient;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -25,22 +27,16 @@ import org.junit.runners.model.Statement;
 
 import org.springframework.integration.kafka.core.ZookeeperConnectDefaults;
 
-import kafka.utils.ZKStringSerializer$;
-import kafka.utils.ZkUtils;
-
 /**
- * <p>
- * A rule that prevents integration tests from failing if the Kafka server is not running or not
+ * * A rule that prevents integration tests from failing if the Kafka server is not running or not
  * accessible. If the Kafka server is not running in the background all the tests here will simply be skipped because
  * of a violated assumption (showing as successful).
- * <p>
  * The rule can be declared as static so that it only has to check once for all tests in the enclosing test case, but
  * there isn't a lot of overhead in making it non-static.
  *
  * @author Dave Syer
  * @author Artem Bilan
  * @author Gary Russell
- *
  * @since 1.0
  */
 public class KafkaRunning extends TestWatcher {
@@ -49,14 +45,14 @@ public class KafkaRunning extends TestWatcher {
 
 	private static final Log logger = LogFactory.getLog(KafkaRunning.class);
 
+	private ZkClient zkClient;
+
 	/**
 	 * @return a new rule that assumes an existing running broker
 	 */
 	public static KafkaRunning isRunning() {
 		return new KafkaRunning();
 	}
-
-	private ZkClient zkClient;
 
 	public ZkClient getZkClient() {
 		return zkClient;

--- a/src/test/resources/kafka-integration-no-namespace.xml
+++ b/src/test/resources/kafka-integration-no-namespace.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans"
-	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:int="http://www.springframework.org/schema/integration"
-	   xmlns:util="http://www.springframework.org/schema/util"
-	   xmlns:context="http://www.springframework.org/schema/context"
-	   xsi:schemaLocation="
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+			 xmlns:int="http://www.springframework.org/schema/integration"
+			 xmlns:util="http://www.springframework.org/schema/util"
+			 xmlns:context="http://www.springframework.org/schema/context"
+			 xmlns="http://www.springframework.org/schema/beans"
+			 xsi:schemaLocation="
 	   http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 	   http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
 	   http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
@@ -35,14 +35,16 @@
 	</bean>
 
 
-	<bean id="kafkaMessageListenerContainer" class="org.springframework.integration.kafka.listener.KafkaMessageListenerContainer">
+	<bean id="kafkaMessageListenerContainer"
+				class="org.springframework.integration.kafka.listener.KafkaMessageListenerContainer">
 		<constructor-arg index="0" ref="connectionFactory"/>
 		<constructor-arg index="1" ref="partitions"/>
 		<property name="timeout" value="10000"/>
 		<property name="maxSize" value="100"/>
 	</bean>
 
-	<bean id="kafkaInboundChannelAdapter" class="org.springframework.integration.kafka.inbound.KafkaInboundChannelAdapter">
+	<bean id="kafkaInboundChannelAdapter"
+				class="org.springframework.integration.kafka.inbound.KafkaInboundChannelAdapter">
 		<constructor-arg index="0" ref="kafkaMessageListenerContainer"/>
 		<property name="outputChannel" ref="output"/>
 		<property name="keyDecoder">

--- a/src/test/resources/kafka-integration-no-namespace.xml
+++ b/src/test/resources/kafka-integration-no-namespace.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:int="http://www.springframework.org/schema/integration"
+	   xmlns:util="http://www.springframework.org/schema/util"
+	   xmlns:context="http://www.springframework.org/schema/context"
+	   xsi:schemaLocation="
+	   http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+	   http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+	   http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+	   http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+
+	<context:property-placeholder/>
+
+	<util:list id="kafkaBrokerAddresses">
+		<bean class="org.springframework.integration.kafka.core.KafkaBrokerAddress">
+			<constructor-arg index="0" value="localhost"/>
+			<constructor-arg index="1" value="${kafka.test.port}"/>
+		</bean>
+	</util:list>
+
+	<util:list id="partitions">
+		<bean class="org.springframework.integration.kafka.core.Partition">
+			<constructor-arg index="0" value="${kafka.test.topic}"/>
+			<constructor-arg index="1" value="0"/>
+		</bean>
+	</util:list>
+
+	<bean id="kafkaConfiguration" class="org.springframework.integration.kafka.core.KafkaConfiguration">
+		<constructor-arg index="0" ref="kafkaBrokerAddresses"/>
+	</bean>
+
+	<bean id="connectionFactory" class="org.springframework.integration.kafka.core.KafkaBrokerConnectionFactory">
+		<constructor-arg index="0" ref="kafkaConfiguration"/>
+	</bean>
+
+
+	<bean id="kafkaMessageListenerContainer" class="org.springframework.integration.kafka.listener.KafkaMessageListenerContainer">
+		<constructor-arg index="0" ref="connectionFactory"/>
+		<constructor-arg index="1" ref="partitions"/>
+		<property name="timeout" value="10000"/>
+		<property name="maxSize" value="100"/>
+	</bean>
+
+	<bean id="kafkaInboundChannelAdapter" class="org.springframework.integration.kafka.inbound.KafkaInboundChannelAdapter">
+		<constructor-arg index="0" ref="kafkaMessageListenerContainer"/>
+		<property name="outputChannel" ref="output"/>
+		<property name="keyDecoder">
+			<bean class="org.springframework.integration.kafka.serializer.common.StringDecoder"/>
+		</property>
+		<property name="payloadDecoder">
+			<bean class="org.springframework.integration.kafka.serializer.common.StringDecoder"/>
+		</property>
+	</bean>
+
+	<int:channel id="output">
+		<int:queue capacity="100"/>
+	</int:channel>
+</beans>


### PR DESCRIPTION
XD-2357-2391 Initial implementation of Kafka ChannelAdapter using the SimpleConsumer API

The implementation has the following components:

- KafkaConnectionFactory - manages and caches connections to a set of brokers
- KafkaBrokerConnection - handles low-level SimpleConsumer API calls and converts them to internal objects such as KafkaMessage and KafkaMessageBus
- KafkaTemplate - implements higher-level read operations on a Kafka broker
- OffsetManager - stores (potentially in a persistent fashion) offsets for a group of consumers, configures/resets initial offsets as necessary - can be configured to start at an arbitrary offset in a partition (e.g. replay since offset 100), or relative to a given timestamp (e.g. replay since Monday)
- KafkaMessageListenerContainer - retrieves messages from a given broker for an arbitrary set of partitions or topics (i.e. all partitions in the topics), invoking a MessageListener. Concurrency is adjustable, and allows processing multiple sets of partitions in parallel (while preserving ordering within a partition). Can poll multiple brokers (each on a parallel thread)
- AbstractDecodingMessageListener - utility base class for a MessageListener implementation that decodes the payload and key
- KafkaInboundChannelAdapter delegating to the KafkaMessageListenerContainer

Tests:
- Single and multi-broker configurations
- Partition subset retrieval
- Replicated sets
- Compression

TO DO:
- add tests for arbitrary start offsets
- add support for leader change failover
- add support for (optionally) retrieving configuration/leader information from Zookeeper
- namespace support