### PR TITLE
[1.0.1][1.1]INTEXT-153 Properly stop the KafkaMessageListenerContainer

### DIFF
--- a/src/main/java/org/springframework/integration/kafka/listener/ConcurrentMessageListenerDispatcher.java
+++ b/src/main/java/org/springframework/integration/kafka/listener/ConcurrentMessageListenerDispatcher.java
@@ -113,7 +113,9 @@ class ConcurrentMessageListenerDispatcher implements Lifecycle {
 	}
 
 	public void dispatch(KafkaMessage message) {
-		delegates.get(message.getMetadata().getPartition()).enqueue(message);
+		if (isRunning()) {
+			delegates.get(message.getMetadata().getPartition()).enqueue(message);
+		}
 	}
 
 	private void initializeAndStartDispatching() {

--- a/src/main/java/org/springframework/integration/kafka/listener/KafkaMessageListenerContainer.java
+++ b/src/main/java/org/springframework/integration/kafka/listener/KafkaMessageListenerContainer.java
@@ -397,7 +397,7 @@ public class KafkaMessageListenerContainer implements SmartLifecycle {
 							}
 							return;
 						}
-					} while (!hasErrors && !partitionsWithRemainingData.isEmpty());
+					} while (!hasErrors && isRunning() && !partitionsWithRemainingData.isEmpty());
 				}
 			}
 			if (wasInterrupted) {


### PR DESCRIPTION
- ensure that the fetch loop is exited immediately after the listener container is stopped;
- do not dispatch messages for processing once components are stopped;