### PR TITLE
Change expected type of listener-container attribute for message-drive-channel-adapter

### DIFF
--- a/src/main/resources/org/springframework/integration/config/xml/spring-integration-kafka-1.1.xsd
+++ b/src/main/resources/org/springframework/integration/config/xml/spring-integration-kafka-1.1.xsd
@@ -551,7 +551,7 @@
 					</xsd:documentation>
 					<xsd:appinfo>
 						<tool:annotation kind="ref">
-							<tool:expected-type type="org.springframework.integration.kafka.core.ConnectionFactory"/>
+							<tool:expected-type type="org.springframework.integration.kafka.listener.KafkaMessageListenerContainer"/>
 						</tool:annotation>
 					</xsd:appinfo>
 				</xsd:annotation>


### PR DESCRIPTION
Currently the expected type of the listener-container attribute of the message-driven-channel-adapter for the kafka-int schema is org.springframework.integration.kafka.core.ConnectionFactory instead of the true required type of org.springframework.integration.kafka.listener.KafkaMessageListenerContainer.  While not enforced at run time, this does report as a break in spring schema parsers, such as the one included with Intellij IDEA.

Regards,
Kevin