### PR TITLE
INTEXT-168 Upgrade to Kafka 0.8.2.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,13 +14,13 @@ repositories {
 	maven { url 'http://repo.spring.io/libs-milestone' }
 }
 
-sourceCompatibility = targetCompatibility = 1.6
+sourceCompatibility = targetCompatibility = 1.7
 
 ext {
 	avroVersion = '1.7.6'
 	gsCollectionsVersion = '5.0.0'
 	jacocoVersion = '0.7.2.201409121644'
-	kafkaVersion = '0.8.1.1'
+	kafkaVersion = '0.8.2.1'
 	metricsVersion = '2.2.0'
 	scalaVersion = '2.10'
 	springIntegrationVersion = '4.1.3.RELEASE'
@@ -66,6 +66,8 @@ dependencies {
 		exclude module: 'jmxtools'
 		exclude module: 'jmxri'
 	}
+
+	compile "org.apache.kafka:kafka-clients:$kafkaVersion"
 
 	testCompile "org.springframework.integration:spring-integration-test:$springIntegrationVersion"
 	testCompile "org.springframework.integration:spring-integration-stream:$springIntegrationVersion"

--- a/src/main/java/org/springframework/integration/kafka/config/xml/KafkaOutboundChannelAdapterParser.java
+++ b/src/main/java/org/springframework/integration/kafka/config/xml/KafkaOutboundChannelAdapterParser.java
@@ -60,6 +60,13 @@ public class KafkaOutboundChannelAdapterParser extends AbstractOutboundChannelAd
 			kafkaProducerMessageHandlerBuilder.addPropertyValue("messageKeyExpression", messageKeyExpressionDef);
 		}
 
+		BeanDefinition partitionIdExpressionDef =
+				IntegrationNamespaceUtils.createExpressionDefinitionFromValueOrExpression("partition-id",
+						"partition-id-expression", parserContext, element, false);
+		if (partitionIdExpressionDef != null) {
+			kafkaProducerMessageHandlerBuilder.addPropertyValue("partitionIdExpression", partitionIdExpressionDef);
+		}
+
 		return kafkaProducerMessageHandlerBuilder.getBeanDefinition();
 	}
 

--- a/src/main/java/org/springframework/integration/kafka/config/xml/KafkaProducerContextParser.java
+++ b/src/main/java/org/springframework/integration/kafka/config/xml/KafkaProducerContextParser.java
@@ -18,6 +18,8 @@ package org.springframework.integration.kafka.config.xml;
 
 import java.util.Map;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.w3c.dom.Element;
 
 import org.springframework.beans.BeanMetadataElement;
@@ -31,6 +33,8 @@ import org.springframework.integration.kafka.support.KafkaProducerContext;
 import org.springframework.integration.kafka.support.ProducerConfiguration;
 import org.springframework.integration.kafka.support.ProducerFactoryBean;
 import org.springframework.integration.kafka.support.ProducerMetadata;
+import org.springframework.integration.kafka.util.EncoderAdaptingSerializer;
+import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 import org.springframework.util.xml.DomUtils;
 
@@ -41,6 +45,8 @@ import org.springframework.util.xml.DomUtils;
  * @since 0.5
  */
 public class KafkaProducerContextParser extends AbstractSimpleBeanDefinitionParser {
+
+	private static final Log log = LogFactory.getLog(KafkaProducerContextParser.class);
 
 	@Override
 	protected Class<?> getBeanClass(final Element element) {
@@ -65,7 +71,7 @@ public class KafkaProducerContextParser extends AbstractSimpleBeanDefinitionPars
 	}
 
 	private void parseProducerConfigurations(Element topics, ParserContext parserContext,
-			BeanDefinitionBuilder builder, Element parentElem) {
+																					 BeanDefinitionBuilder builder, Element parentElem) {
 		Map<String, BeanMetadataElement> producerConfigurationsMap = new ManagedMap<String, BeanMetadataElement>();
 
 		for (Element producerConfiguration : DomUtils.getChildElementsByTagName(topics, "producer-configuration")) {
@@ -73,22 +79,52 @@ public class KafkaProducerContextParser extends AbstractSimpleBeanDefinitionPars
 			BeanDefinitionBuilder producerMetadataBuilder =
 					BeanDefinitionBuilder.genericBeanDefinition(ProducerMetadata.class);
 			producerMetadataBuilder.addConstructorArgValue(producerConfiguration.getAttribute("topic"));
-			IntegrationNamespaceUtils.setReferenceIfAttributeDefined(producerMetadataBuilder, producerConfiguration,
-					"value-encoder");
-			IntegrationNamespaceUtils.setReferenceIfAttributeDefined(producerMetadataBuilder, producerConfiguration,
-					"key-encoder");
-			IntegrationNamespaceUtils.setValueIfAttributeDefined(producerMetadataBuilder, producerConfiguration,
-					"key-class-type");
-			IntegrationNamespaceUtils.setValueIfAttributeDefined(producerMetadataBuilder, producerConfiguration,
-					"value-class-type");
+			producerMetadataBuilder.addConstructorArgValue(producerConfiguration.getAttribute("key-class-type"));
+			producerMetadataBuilder.addConstructorArgValue(producerConfiguration.getAttribute("value-class-type"));
+
+			String keySerializer = producerConfiguration.getAttribute("key-serializer");
+			String keyEncoder = producerConfiguration.getAttribute("key-encoder");
+			Assert.isTrue((StringUtils.hasText(keySerializer) ^ StringUtils.hasText(keyEncoder)),
+					"Exactly one of 'key-serializer' or 'key-encoder' can be specified");
+			if (StringUtils.hasText(keyEncoder)) {
+				if (log.isWarnEnabled()) {
+					log.warn("'key-encoder' is a deprecated option, use 'key-serializer' instead.");
+				}
+				BeanDefinitionBuilder encoderAdaptingSerializerBean = BeanDefinitionBuilder.genericBeanDefinition(EncoderAdaptingSerializer.class);
+				encoderAdaptingSerializerBean.addConstructorArgReference(keyEncoder);
+				producerMetadataBuilder.addConstructorArgValue(encoderAdaptingSerializerBean.getBeanDefinition());
+			}
+			else {
+				producerMetadataBuilder.addConstructorArgReference(keySerializer);
+			}
+
+			String valueSerializer = producerConfiguration.getAttribute("value-serializer");
+			String valueEncoder = producerConfiguration.getAttribute("value-encoder");
+			Assert.isTrue((StringUtils.hasText(valueSerializer) ^ StringUtils.hasText(valueEncoder)),
+					"Exactly one of 'value-serializer' or 'value-encoder' must be specified");
+			if (StringUtils.hasText(valueEncoder)) {
+				if (log.isWarnEnabled()) {
+					log.warn("'value-encoder' is a deprecated option, use 'value-serializer' instead.");
+				}
+				BeanDefinitionBuilder encoderAdaptingSerializerBean = BeanDefinitionBuilder.genericBeanDefinition(EncoderAdaptingSerializer.class);
+				encoderAdaptingSerializerBean.addConstructorArgReference(valueEncoder);
+				producerMetadataBuilder.addConstructorArgValue(encoderAdaptingSerializerBean.getBeanDefinition());
+			}
+			else {
+				producerMetadataBuilder.addConstructorArgReference(valueSerializer);
+			}
+
 			IntegrationNamespaceUtils.setReferenceIfAttributeDefined(producerMetadataBuilder, producerConfiguration,
 					"partitioner");
+			if (StringUtils.hasText(producerConfiguration.getAttribute("partitioner"))) {
+				if (log.isWarnEnabled()) {
+					log.warn("'partitioner' is a deprecated option. Use the 'kafka_partitionId' message header or the partition argument in the send() or convertAndSend() methods");
+				}
+			}
 			IntegrationNamespaceUtils.setValueIfAttributeDefined(producerMetadataBuilder, producerConfiguration,
-					"compression-codec");
+					"compression-type");
 			IntegrationNamespaceUtils.setValueIfAttributeDefined(producerMetadataBuilder, producerConfiguration,
-					"async");
-			IntegrationNamespaceUtils.setValueIfAttributeDefined(producerMetadataBuilder, producerConfiguration,
-					"batch-num-messages");
+					"batch-bytes");
 			AbstractBeanDefinition producerMetadataBeanDefinition = producerMetadataBuilder.getBeanDefinition();
 
 			String producerPropertiesBean = parentElem.getAttribute("producer-properties");
@@ -108,13 +144,14 @@ public class KafkaProducerContextParser extends AbstractSimpleBeanDefinitionPars
 
 			AbstractBeanDefinition producerFactoryBeanDefinition = producerFactoryBuilder.getBeanDefinition();
 
-			AbstractBeanDefinition producerConfigurationBeanDefinition =
+			BeanDefinitionBuilder producerConfigurationBuilder =
 					BeanDefinitionBuilder.genericBeanDefinition(ProducerConfiguration.class)
 							.addConstructorArgValue(producerMetadataBeanDefinition)
-							.addConstructorArgValue(producerFactoryBeanDefinition)
-							.getBeanDefinition();
+							.addConstructorArgValue(producerFactoryBeanDefinition);
+			IntegrationNamespaceUtils.setReferenceIfAttributeDefined(producerConfigurationBuilder, producerConfiguration,
+					"conversion-service");
 			producerConfigurationsMap.put(producerConfiguration.getAttribute("topic"),
-					producerConfigurationBeanDefinition);
+					producerConfigurationBuilder.getBeanDefinition());
 		}
 
 		builder.addPropertyValue("producerConfigurations", producerConfigurationsMap);

--- a/src/main/java/org/springframework/integration/kafka/config/xml/KafkaProducerContextParser.java
+++ b/src/main/java/org/springframework/integration/kafka/config/xml/KafkaProducerContextParser.java
@@ -71,7 +71,7 @@ public class KafkaProducerContextParser extends AbstractSimpleBeanDefinitionPars
 	}
 
 	private void parseProducerConfigurations(Element topics, ParserContext parserContext,
-																					 BeanDefinitionBuilder builder, Element parentElem) {
+			BeanDefinitionBuilder builder, Element parentElem) {
 		Map<String, BeanMetadataElement> producerConfigurationsMap = new ManagedMap<String, BeanMetadataElement>();
 
 		for (Element producerConfiguration : DomUtils.getChildElementsByTagName(topics, "producer-configuration")) {
@@ -85,7 +85,7 @@ public class KafkaProducerContextParser extends AbstractSimpleBeanDefinitionPars
 			String keySerializer = producerConfiguration.getAttribute("key-serializer");
 			String keyEncoder = producerConfiguration.getAttribute("key-encoder");
 			Assert.isTrue((StringUtils.hasText(keySerializer) ^ StringUtils.hasText(keyEncoder)),
-					"Exactly one of 'key-serializer' or 'key-encoder' can be specified");
+					"Exactly one of 'key-serializer' or 'key-encoder' must be specified");
 			if (StringUtils.hasText(keyEncoder)) {
 				if (log.isWarnEnabled()) {
 					log.warn("'key-encoder' is a deprecated option, use 'key-serializer' instead.");
@@ -106,7 +106,8 @@ public class KafkaProducerContextParser extends AbstractSimpleBeanDefinitionPars
 				if (log.isWarnEnabled()) {
 					log.warn("'value-encoder' is a deprecated option, use 'value-serializer' instead.");
 				}
-				BeanDefinitionBuilder encoderAdaptingSerializerBean = BeanDefinitionBuilder.genericBeanDefinition(EncoderAdaptingSerializer.class);
+				BeanDefinitionBuilder encoderAdaptingSerializerBean =
+						BeanDefinitionBuilder.genericBeanDefinition(EncoderAdaptingSerializer.class);
 				encoderAdaptingSerializerBean.addConstructorArgReference(valueEncoder);
 				producerMetadataBuilder.addConstructorArgValue(encoderAdaptingSerializerBean.getBeanDefinition());
 			}
@@ -118,7 +119,8 @@ public class KafkaProducerContextParser extends AbstractSimpleBeanDefinitionPars
 					"partitioner");
 			if (StringUtils.hasText(producerConfiguration.getAttribute("partitioner"))) {
 				if (log.isWarnEnabled()) {
-					log.warn("'partitioner' is a deprecated option. Use the 'kafka_partitionId' message header or the partition argument in the send() or convertAndSend() methods");
+					log.warn("'partitioner' is a deprecated option. Use the 'kafka_partitionId' message header or " +
+							"the partition argument in the send() or convertAndSend() methods");
 				}
 			}
 			IntegrationNamespaceUtils.setValueIfAttributeDefined(producerMetadataBuilder, producerConfiguration,

--- a/src/main/java/org/springframework/integration/kafka/listener/AbstractOffsetManager.java
+++ b/src/main/java/org/springframework/integration/kafka/listener/AbstractOffsetManager.java
@@ -135,7 +135,11 @@ public abstract class AbstractOffsetManager implements OffsetManager, Disposable
 				Connection connection = this.connectionFactory.connect(leader);
 				Result<Long> offsetResult = connection.fetchInitialOffset(this.referenceTimestamp, partition);
 				if (offsetResult.getErrors().size() > 0) {
-					throw new ConsumerException(ErrorMapping.exceptionFor(offsetResult.getError(partition)));
+					short errorCode = offsetResult.getError(partition);
+					if (log.isWarnEnabled()) {
+						log.warn("Error code while retrieving offset for partition " + partition.toString() + " : " + errorCode);
+					}
+					throw new ConsumerException(ErrorMapping.exceptionFor(errorCode));
 				}
 				if (!offsetResult.getResults().containsKey(partition)) {
 					throw new IllegalStateException("Result does not contain an expected value");

--- a/src/main/java/org/springframework/integration/kafka/listener/ConcurrentMessageListenerDispatcher.java
+++ b/src/main/java/org/springframework/integration/kafka/listener/ConcurrentMessageListenerDispatcher.java
@@ -22,6 +22,9 @@ import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 import org.springframework.integration.kafka.core.KafkaMessage;
 import org.springframework.integration.kafka.core.Partition;
 import org.springframework.scheduling.concurrent.CustomizableThreadFactory;
@@ -30,8 +33,6 @@ import org.springframework.util.Assert;
 import com.gs.collections.api.block.procedure.Procedure2;
 import com.gs.collections.api.map.MutableMap;
 import com.gs.collections.impl.factory.Maps;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 
 /**
  * Dispatches {@link KafkaMessage}s to a {@link MessageListener}. Messages may be
@@ -71,7 +72,7 @@ class ConcurrentMessageListenerDispatcher {
 	private Executor taskExecutor;
 
 	public ConcurrentMessageListenerDispatcher(Object delegateListener, ErrorHandler errorHandler,
-			Collection<Partition> partitions, OffsetManager offsetManager, int consumers, int queueSize) {
+			Collection<Partition> partitions, OffsetManager offsetManager, int consumers, int queueSize, Executor taskExecutor) {
 		Assert.isTrue
 				(delegateListener instanceof MessageListener
 								|| delegateListener instanceof AcknowledgingMessageListener,
@@ -87,6 +88,7 @@ class ConcurrentMessageListenerDispatcher {
 		this.offsetManager = offsetManager;
 		this.consumers = consumers;
 		this.queueSize = queueSize;
+		this.taskExecutor = taskExecutor;
 	}
 
 	public void start() {
@@ -104,7 +106,6 @@ class ConcurrentMessageListenerDispatcher {
 				this.running = false;
 				delegates.flip().keyBag().toSet().forEachWith(stopDelegateProcedure, stopTimeout);
 			}
-			this.taskExecutor = null;
 			this.delegates = null;
 		}
 	}

--- a/src/main/java/org/springframework/integration/kafka/listener/LongSerializerDecoder.java
+++ b/src/main/java/org/springframework/integration/kafka/listener/LongSerializerDecoder.java
@@ -17,23 +17,24 @@
 package org.springframework.integration.kafka.listener;
 
 import java.nio.ByteBuffer;
-
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
-import org.springframework.integration.kafka.util.LoggingUtils;
+import java.util.Map;
 
 import kafka.serializer.Decoder;
 import kafka.serializer.Encoder;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.kafka.common.serialization.Serializer;
+
+import org.springframework.integration.kafka.util.LoggingUtils;
 
 /**
  * Kafka {@link Encoder} and {@link Decoder} for Long values.
  *
  * @author Marius Bogoevici
  */
-public class LongEncoderDecoder implements Encoder<Long>, Decoder<Long> {
+public class LongSerializerDecoder implements Serializer<Long>, Decoder<Long> {
 
-	private Log log = LogFactory.getLog(LongEncoderDecoder.class);
+	private Log log = LogFactory.getLog(LongSerializerDecoder.class);
 
 	@Override
 	public Long fromBytes(byte[] bytes) {
@@ -54,13 +55,22 @@ public class LongEncoderDecoder implements Encoder<Long>, Decoder<Long> {
 	}
 
 	@Override
-	public byte[] toBytes(Long value) {
-		if (value == null) {
+	public void configure(Map<String, ?> configs, boolean isKey) {
+		// no-op
+	}
+
+	@Override
+	public byte[] serialize(String topic, Long data) {
+		if (data == null) {
 			return null;
 		}
 		else {
-			return ByteBuffer.allocate(8).putLong(value).array();
+			return ByteBuffer.allocate(8).putLong(data).array();
 		}
 	}
 
+	@Override
+	public void close() {
+		// no-op
+	}
 }

--- a/src/main/java/org/springframework/integration/kafka/serializer/common/StringEncoder.java
+++ b/src/main/java/org/springframework/integration/kafka/serializer/common/StringEncoder.java
@@ -15,28 +15,33 @@
  */
 package org.springframework.integration.kafka.serializer.common;
 
+import java.util.Properties;
+
 import kafka.serializer.Encoder;
 import kafka.utils.VerifiableProperties;
 
-import java.util.Properties;
-
 /**
  * @author Soby Chacko
+ * @author Marius Bogoevici
  * @since 0.5
  */
-public class StringEncoder<T> implements Encoder<T> {
-	private String encoding = "UTF8";
+public class StringEncoder implements Encoder<String> {
 
-	public void setEncoding(final String encoding){
-		this.encoding = encoding;
+	private kafka.serializer.StringEncoder stringEncoder;
+
+	public StringEncoder() {
+		this("UTF-8");
+	}
+
+	public StringEncoder(String encoding) {
+		final Properties props = new Properties();
+		props.put("serializer.encoding", encoding);
+		final VerifiableProperties verifiableProperties = new VerifiableProperties(props);
+		stringEncoder = new kafka.serializer.StringEncoder(verifiableProperties);
 	}
 
 	@Override
-	public byte[] toBytes(final Object o) {
-		final Properties props = new Properties();
-		props.put("serializer.encoding", encoding);
-
-		final VerifiableProperties verifiableProperties = new VerifiableProperties(props);
-		return new kafka.serializer.StringEncoder(verifiableProperties).toBytes((String)o);
+	public byte[] toBytes(final String value) {
+		return stringEncoder.toBytes(value);
 	}
 }

--- a/src/main/java/org/springframework/integration/kafka/support/ProducerConfiguration.java
+++ b/src/main/java/org/springframework/integration/kafka/support/ProducerConfiguration.java
@@ -16,27 +16,26 @@
 
 package org.springframework.integration.kafka.support;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.ObjectOutputStream;
+import java.util.concurrent.Future;
 
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
 
-import org.springframework.messaging.Message;
-import org.springframework.messaging.MessageHandlingException;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.core.convert.support.GenericConversionService;
+import org.springframework.core.serializer.support.SerializingConverter;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
-
-import kafka.javaapi.producer.Producer;
-import kafka.producer.KeyedMessage;
-import kafka.serializer.DefaultEncoder;
 
 /**
  * @author Soby Chacko
  * @author Rajasekar Elango
  * @author Ilayaperumal Gopinathan
  * @author Gary Russell
+ * @author Marius Bogoevici
  * @since 0.5
  */
 public class ProducerConfiguration<K, V> {
@@ -45,63 +44,70 @@ public class ProducerConfiguration<K, V> {
 
 	private final ProducerMetadata<K, V> producerMetadata;
 
+	private ConversionService conversionService;
+
 	public ProducerConfiguration(ProducerMetadata<K, V> producerMetadata, Producer<K, V> producer) {
 		Assert.notNull(producerMetadata);
 		Assert.notNull(producer);
 		this.producerMetadata = producerMetadata;
 		this.producer = producer;
+		GenericConversionService genericConversionService = new GenericConversionService();
+		genericConversionService.addConverter(Object.class, byte[].class, new SerializingConverter());
+		conversionService = genericConversionService;
+	}
+
+	public void setConversionService(ConversionService conversionService) {
+		Assert.notNull(conversionService, "Conversion service must not be null");
+		this.conversionService = conversionService;
 	}
 
 	public ProducerMetadata<K, V> getProducerMetadata() {
 		return this.producerMetadata;
 	}
 
-	public Producer<K, V> getProducer() {
-		return this.producer;
+	public Future<RecordMetadata> send(String topic, K messageKey, V messagePayload) {
+		if (this.getProducerMetadata().getPartitioner() != null) {
+			String targetTopic = StringUtils.hasText(topic) ? topic : this.producerMetadata.getTopic();
+			int partition = this.getProducerMetadata().getPartitioner().partition(messageKey,
+					this.producer.partitionsFor(targetTopic).size());
+			return this.send(targetTopic, partition, messageKey, messagePayload);
+		}
+		return this.send(topic, null, messageKey, messagePayload);
 	}
 
-	public void send(String topic, Object messageKey, final Message<?> message) throws Exception {
-		final V v = getPayload(message);
-
-		if (!StringUtils.hasText(topic)) {
-			topic = this.producerMetadata.getTopic();
-		}
-
-		this.producer.send(new KeyedMessage<K, V>(topic, (messageKey != null ? getKey(messageKey) : null), v));
+	public Future<RecordMetadata> send(String topic, Integer partition, K messageKey, V messagePayload) {
+		String targetTopic = StringUtils.hasText(topic) ? topic : this.producerMetadata.getTopic();
+		return this.producer.send(new ProducerRecord<>(targetTopic, partition, messageKey, messagePayload));
 	}
 
-	@SuppressWarnings("unchecked")
-	private V getPayload(final Message<?> message) throws Exception {
-		if (this.producerMetadata.getValueEncoder() instanceof DefaultEncoder) {
-			return (V) getByteStream(message.getPayload());
-		}
-		else if (producerMetadata.getValueClassType().isAssignableFrom(message.getPayload().getClass())) {
-			return producerMetadata.getValueClassType().cast(message.getPayload());
-		}
-		throw new MessageHandlingException(message, "Message payload type is not matching with what is configured");
+	public Future<RecordMetadata> convertAndSend(String topic, Integer partition, Object messageKey, Object messagePayload) {
+		return this.send(topic, partition, convertKeyIfNecessary(messageKey), convertPayloadIfNecessary(messagePayload));
 	}
 
-	@SuppressWarnings("unchecked")
-	private K getKey(Object messageKey) throws Exception {
-		if (this.producerMetadata.getKeyEncoder() instanceof DefaultEncoder) {
-			return (K) getByteStream(messageKey);
-		}
-
-		return (K) messageKey;
+	public Future<RecordMetadata> convertAndSend(String topic, Object messageKey, Object messagePayload) {
+		return this.send(topic, convertKeyIfNecessary(messageKey), convertPayloadIfNecessary(messagePayload));
 	}
 
-	private static boolean isRawByteArray(final Object obj) {
-		return obj instanceof byte[];
+	private K convertKeyIfNecessary(Object messageKey) {
+		if (messageKey != null) {
+			if (getProducerMetadata().getKeyClassType().isAssignableFrom(messageKey.getClass())) {
+				return getProducerMetadata().getKeyClassType().cast(messageKey);
+			}
+			return conversionService.convert(messageKey, producerMetadata.getKeyClassType());
+		} else {
+			return null;
+		}
 	}
 
-	private static byte[] getByteStream(final Object obj) throws IOException {
-		if (isRawByteArray(obj)) {
-			return (byte[]) obj;
+	private V convertPayloadIfNecessary(Object messagePayload) {
+		if (messagePayload != null) {
+			if (getProducerMetadata().getKeyClassType().isAssignableFrom(messagePayload.getClass())) {
+				return getProducerMetadata().getValueClassType().cast(messagePayload);
+			}
+			return conversionService.convert(messagePayload, producerMetadata.getValueClassType());
+		} else {
+			return null;
 		}
-		final ByteArrayOutputStream out = new ByteArrayOutputStream();
-		final ObjectOutputStream os = new ObjectOutputStream(out);
-		os.writeObject(obj);
-		return out.toByteArray();
 	}
 
 	@Override

--- a/src/main/java/org/springframework/integration/kafka/support/ProducerConfiguration.java
+++ b/src/main/java/org/springframework/integration/kafka/support/ProducerConfiguration.java
@@ -90,22 +90,28 @@ public class ProducerConfiguration<K, V> {
 
 	private K convertKeyIfNecessary(Object messageKey) {
 		if (messageKey != null) {
-			if (getProducerMetadata().getKeyClassType().isAssignableFrom(messageKey.getClass())) {
+			if (getProducerMetadata().getKeyClassType().isAssignableFrom(
+					messageKey.getClass())) {
 				return getProducerMetadata().getKeyClassType().cast(messageKey);
 			}
-			return conversionService.convert(messageKey, producerMetadata.getKeyClassType());
-		} else {
+			return conversionService.convert(messageKey,
+					producerMetadata.getKeyClassType());
+		}
+		else {
 			return null;
 		}
 	}
 
 	private V convertPayloadIfNecessary(Object messagePayload) {
 		if (messagePayload != null) {
-			if (getProducerMetadata().getKeyClassType().isAssignableFrom(messagePayload.getClass())) {
+			if (getProducerMetadata().getKeyClassType().isAssignableFrom(
+					messagePayload.getClass())) {
 				return getProducerMetadata().getValueClassType().cast(messagePayload);
 			}
-			return conversionService.convert(messagePayload, producerMetadata.getValueClassType());
-		} else {
+			return conversionService.convert(messagePayload,
+					producerMetadata.getValueClassType());
+		}
+		else {
 			return null;
 		}
 	}

--- a/src/main/java/org/springframework/integration/kafka/util/EncoderAdaptingSerializer.java
+++ b/src/main/java/org/springframework/integration/kafka/util/EncoderAdaptingSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright ${today.year} the original author or authors.
+ * Copyright 2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/integration/kafka/util/EncoderAdaptingSerializer.java
+++ b/src/main/java/org/springframework/integration/kafka/util/EncoderAdaptingSerializer.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright ${today.year} the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.kafka.util;
+
+import java.util.Map;
+
+import kafka.serializer.DefaultEncoder;
+import kafka.serializer.Encoder;
+import org.apache.kafka.common.serialization.Serializer;
+
+/**
+ * An adapter from the pre-0.8.2 Kafka {@link Encoder} to the {@link Serializer} interface used
+ * by the new client.
+ *
+ * @author Marius Bogoevici
+ */
+public class EncoderAdaptingSerializer<T> implements Serializer<T> {
+
+	private final Encoder<T> encoder;
+
+	public EncoderAdaptingSerializer(Encoder<T> encoder) {
+		this.encoder = encoder;
+	}
+
+	public Encoder<T> getEncoder() {
+		return encoder;
+	}
+
+	@Override
+	public void configure(Map<String, ?> configs, boolean isKey) {
+		// no-op
+	}
+
+	@Override
+	public byte[] serialize(String topic, T data) {
+		return encoder.toBytes(data);
+	}
+
+	@Override
+	public void close() {
+		// no-op;
+	}
+}

--- a/src/main/resources/META-INF/spring.schemas
+++ b/src/main/resources/META-INF/spring.schemas
@@ -1,2 +1,2 @@
-http\://www.springframework.org/schema/integration/kafka/spring-integration-kafka-1.1.xsd=org/springframework/integration/config/xml/spring-integration-kafka-1.1.xsd
-http\://www.springframework.org/schema/integration/kafka/spring-integration-kafka.xsd=org/springframework/integration/config/xml/spring-integration-kafka-1.1.xsd
+http\://www.springframework.org/schema/integration/kafka/spring-integration-kafka-1.1.xsd=org/springframework/integration/config/xml/spring-integration-kafka-1.2.xsd
+http\://www.springframework.org/schema/integration/kafka/spring-integration-kafka.xsd=org/springframework/integration/config/xml/spring-integration-kafka-1.2.xsd

--- a/src/main/resources/META-INF/spring.schemas
+++ b/src/main/resources/META-INF/spring.schemas
@@ -1,2 +1,2 @@
-http\://www.springframework.org/schema/integration/kafka/spring-integration-kafka-1.1.xsd=org/springframework/integration/config/xml/spring-integration-kafka-1.2.xsd
+http\://www.springframework.org/schema/integration/kafka/spring-integration-kafka-1.2.xsd=org/springframework/integration/config/xml/spring-integration-kafka-1.2.xsd
 http\://www.springframework.org/schema/integration/kafka/spring-integration-kafka.xsd=org/springframework/integration/config/xml/spring-integration-kafka-1.2.xsd

--- a/src/main/resources/org/springframework/integration/config/xml/spring-integration-kafka-1.2.xsd
+++ b/src/main/resources/org/springframework/integration/config/xml/spring-integration-kafka-1.2.xsd
@@ -109,7 +109,7 @@
 										<xsd:annotation>
 											<xsd:appinfo>
 												<xsd:documentation>
-													Class type used for the value
+													Class type used for the key
 												</xsd:documentation>
 												<tool:annotation kind="direct">
 													<tool:expected-type type="java.lang.Class"/>
@@ -133,7 +133,7 @@
 										<xsd:annotation>
 											<xsd:appinfo>
 												<xsd:documentation>
-													Custom implementation of a Kafka Encoder for encoding message values.
+													Custom implementation of a Kafka Encoder for encoding message values. This option is deprecated, 'value-serializer' is the recommended option.
 												</xsd:documentation>
 												<tool:annotation kind="ref">
 													<tool:expected-type type="kafka.serializer.Encoder"/>
@@ -145,7 +145,7 @@
 										<xsd:annotation>
 											<xsd:appinfo>
 												<xsd:documentation>
-													Custom implementation of a Kafka Encoder for encoding message values.
+													Custom implementation of a Kafka Serializer for message values.
 												</xsd:documentation>
 												<tool:annotation kind="ref">
 													<tool:expected-type type="org.apache.kafka.common.serialization.Serializer"/>
@@ -169,7 +169,7 @@
 										<xsd:annotation>
 											<xsd:appinfo>
 												<xsd:documentation>
-													Custom implementation of a Kafka Encoder for encoding message keys.
+													Custom implementation of a Kafka Serializer for message keys.
 												</xsd:documentation>
 												<tool:annotation kind="ref">
 													<tool:expected-type type="kafka.serializer.Encoder"/>

--- a/src/main/resources/org/springframework/integration/config/xml/spring-integration-kafka-1.2.xsd
+++ b/src/main/resources/org/springframework/integration/config/xml/spring-integration-kafka-1.2.xsd
@@ -105,6 +105,30 @@
                                             ]]></xsd:documentation>
 										</xsd:annotation>
 									</xsd:attribute>
+									<xsd:attribute name="key-class-type" use="optional" type="xsd:string" default="[B">
+										<xsd:annotation>
+											<xsd:appinfo>
+												<xsd:documentation>
+													Class type used for the value
+												</xsd:documentation>
+												<tool:annotation kind="direct">
+													<tool:expected-type type="java.lang.Class"/>
+												</tool:annotation>
+											</xsd:appinfo>
+										</xsd:annotation>
+									</xsd:attribute>
+									<xsd:attribute name="value-class-type" use="optional" type="xsd:string" default="[B">
+										<xsd:annotation>
+											<xsd:appinfo>
+												<xsd:documentation>
+													Class type used for the value
+												</xsd:documentation>
+												<tool:annotation kind="direct">
+													<tool:expected-type type="java.lang.Class"/>
+												</tool:annotation>
+											</xsd:appinfo>
+										</xsd:annotation>
+									</xsd:attribute>
 									<xsd:attribute name="value-encoder" use="optional" type="xsd:string">
 										<xsd:annotation>
 											<xsd:appinfo>
@@ -113,6 +137,18 @@
 												</xsd:documentation>
 												<tool:annotation kind="ref">
 													<tool:expected-type type="kafka.serializer.Encoder"/>
+												</tool:annotation>
+											</xsd:appinfo>
+										</xsd:annotation>
+									</xsd:attribute>
+									<xsd:attribute name="value-serializer" use="optional" type="xsd:string">
+										<xsd:annotation>
+											<xsd:appinfo>
+												<xsd:documentation>
+													Custom implementation of a Kafka Encoder for encoding message values.
+												</xsd:documentation>
+												<tool:annotation kind="ref">
+													<tool:expected-type type="org.apache.kafka.common.serialization.Serializer"/>
 												</tool:annotation>
 											</xsd:appinfo>
 										</xsd:annotation>
@@ -129,31 +165,31 @@
 											</xsd:appinfo>
 										</xsd:annotation>
 									</xsd:attribute>
-									<xsd:attribute name="key-class-type" use="optional" type="xsd:string">
+									<xsd:attribute name="key-serializer" use="optional" type="xsd:string">
 										<xsd:annotation>
 											<xsd:appinfo>
 												<xsd:documentation>
-													Class type used for the key
+													Custom implementation of a Kafka Encoder for encoding message keys.
 												</xsd:documentation>
-												<tool:annotation kind="direct">
-													<tool:expected-type type="java.lang.Class"/>
+												<tool:annotation kind="ref">
+													<tool:expected-type type="kafka.serializer.Encoder"/>
 												</tool:annotation>
 											</xsd:appinfo>
 										</xsd:annotation>
 									</xsd:attribute>
-									<xsd:attribute name="value-class-type" use="optional" type="xsd:string">
+									<xsd:attribute name="conversion-service" use="optional" type="xsd:string">
 										<xsd:annotation>
 											<xsd:appinfo>
 												<xsd:documentation>
-													Class type used for the value
+													Conversion service for transforming inbound objects into the target key and value
 												</xsd:documentation>
-												<tool:annotation kind="direct">
-													<tool:expected-type type="java.lang.Class"/>
+												<tool:annotation kind="ref">
+													<tool:expected-type type="org.springframework.core.convert.ConversionService"/>
 												</tool:annotation>
 											</xsd:appinfo>
 										</xsd:annotation>
 									</xsd:attribute>
-									<xsd:attribute name="compression-codec" use="optional" type="xsd:string">
+									<xsd:attribute name="compression-type" use="optional" type="xsd:string">
 										<xsd:annotation>
 											<xsd:documentation><![CDATA[
                                                 Indicates the type of compression codec used for message compression.
@@ -172,17 +208,7 @@
 											</xsd:appinfo>
 										</xsd:annotation>
 									</xsd:attribute>
-									<xsd:attribute name="async" use="optional">
-										<xsd:annotation>
-											<xsd:documentation>
-												Indicates if this producer is async or not.
-											</xsd:documentation>
-										</xsd:annotation>
-										<xsd:simpleType>
-											<xsd:union memberTypes="xsd:boolean xsd:string"/>
-										</xsd:simpleType>
-									</xsd:attribute>
-									<xsd:attribute name="batch-num-messages" use="optional" type="xsd:string">
+									<xsd:attribute name="batch-bytes" use="optional" type="xsd:string">
 										<xsd:annotation>
 											<xsd:documentation>
 												number of messages to batch at this producer.
@@ -467,6 +493,23 @@
 								Specifies the expression to determine the Key for Kafka message
 								against the Message at runtime.
 								This attribute is mutually exclusive with 'message-key' attribute.
+							]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="partition-id" type="xsd:integer">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+								Specifies the target partition for the Kafka message.
+								This attribute is mutually exclusive with 'partition-id-expression' attribute.
+							]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
+			<xsd:attribute name="partition-id-expression" type="xsd:integer">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+								Specifies the expression to determine the partition for Kafka message
+								against the Message at runtime.
+								This attribute is mutually exclusive with 'partition-id' attribute.
 							]]></xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>

--- a/src/test/java/org/springframework/integration/kafka/config/xml/KafkaOutboundAdapterParserTests-context.xml
+++ b/src/test/java/org/springframework/integration/kafka/config/xml/KafkaOutboundAdapterParserTests-context.xml
@@ -38,10 +38,12 @@
 											  topic="test1"
 											  value-encoder="kafkaEncoder"
 											  key-encoder="kafkaEncoder"
-											  compression-codec="default"/>
+											  compression-type="none"/>
 			<int-kafka:producer-configuration broker-list="localhost:9092"
 											  topic="test2"
-											  compression-codec="default"/>
+											  value-encoder="kafkaEncoder"
+											  key-encoder="kafkaEncoder"
+											  compression-type="none"/>
 		</int-kafka:producer-configurations>
 	</int-kafka:producer-context>
 

--- a/src/test/java/org/springframework/integration/kafka/config/xml/KafkaOutboundAdapterParserTests.java
+++ b/src/test/java/org/springframework/integration/kafka/config/xml/KafkaOutboundAdapterParserTests.java
@@ -41,7 +41,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
-public class KafkaOutboundAdapterParserTests<K, V> {
+public class KafkaOutboundAdapterParserTests {
 
 	@ClassRule
 	public static KafkaRunning kafkaRunning = KafkaRunning.isRunning();
@@ -53,13 +53,13 @@ public class KafkaOutboundAdapterParserTests<K, V> {
 	@SuppressWarnings("unchecked")
 	public void testOutboundAdapterConfiguration() {
 		PollingConsumer pollingConsumer = this.appContext.getBean("kafkaOutboundChannelAdapter", PollingConsumer.class);
-		KafkaProducerMessageHandler<K, V> messageHandler = this.appContext.getBean(KafkaProducerMessageHandler.class);
+		KafkaProducerMessageHandler messageHandler = this.appContext.getBean(KafkaProducerMessageHandler.class);
 		assertNotNull(pollingConsumer);
 		assertNotNull(messageHandler);
 		assertEquals(messageHandler.getOrder(), 3);
 		assertEquals("foo", TestUtils.getPropertyValue(messageHandler, "topicExpression.literalValue"));
 		assertEquals("'bar'", TestUtils.getPropertyValue(messageHandler, "messageKeyExpression.expression"));
-		KafkaProducerContext<K, V> producerContext = messageHandler.getKafkaProducerContext();
+		KafkaProducerContext producerContext = messageHandler.getKafkaProducerContext();
 		assertNotNull(producerContext);
 		assertEquals(producerContext.getProducerConfigurations().size(), 2);
 	}

--- a/src/test/java/org/springframework/integration/kafka/config/xml/KafkaProducerContextParserTests-context.xml
+++ b/src/test/java/org/springframework/integration/kafka/config/xml/KafkaProducerContextParserTests-context.xml
@@ -11,8 +11,8 @@
 	<bean id="producerProperties" class="org.springframework.beans.factory.config.PropertiesFactoryBean">
 		<property name="properties">
 			<props>
-				<prop key="topic.metadata.refresh.interval.ms">3600000</prop>
-                <prop key="message.send.max.retries">5</prop>
+				<prop key="metadata.max.age.ms">3600000</prop>
+                <prop key="retries">5</prop>
                 <prop key="send.buffer.bytes">5242880</prop>
 			</props>
 		</property>
@@ -36,14 +36,27 @@
                                            key-encoder="valueEncoder"
                                            value-encoder="valueEncoder"
                                            topic="${topic1}"
-                                           compression-codec="default"/>
+                                           compression-type="none"/>
             <int-kafka:producer-configuration broker-list="${brokerList2}"
                                            topic="${topic2}"
-                                           compression-codec="default"/>
+                                              key-class-type="java.lang.String"
+                                              value-class-type="java.lang.String"
+                                              key-serializer="stringSerializer"
+                                              value-serializer="stringSerializer"
+                                              batch-bytes="9876"
+                                              partitioner="partitioner"
+                                              conversion-service="conversionService"
+                                           compression-type="none"/>
         </int-kafka:producer-configurations>
     </int-kafka:producer-context>
 
     <bean id="valueEncoder" class="org.springframework.integration.kafka.serializer.avro.AvroReflectDatumBackedKafkaEncoder">
             <constructor-arg value="java.lang.String" />
     </bean>
+
+    <bean id="stringSerializer" class="org.apache.kafka.common.serialization.StringSerializer"/>
+
+    <bean id="partitioner" class="org.springframework.integration.kafka.support.DefaultPartitioner"/>
+
+    <bean id="conversionService" class="org.springframework.integration.kafka.config.xml.KafkaProducerContextParserTests.StubConversionService"/>
 </beans>

--- a/src/test/java/org/springframework/integration/kafka/config/xml/KafkaProducerContextParserTests.java
+++ b/src/test/java/org/springframework/integration/kafka/config/xml/KafkaProducerContextParserTests.java
@@ -15,25 +15,32 @@
  */
 package org.springframework.integration.kafka.config.xml;
 
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
 
 import java.util.Map;
 
-import kafka.javaapi.producer.Producer;
+import kafka.producer.Partitioner;
 import kafka.serializer.Encoder;
-
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.common.serialization.Serializer;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.core.convert.TypeDescriptor;
 import org.springframework.integration.kafka.rule.KafkaRunning;
 import org.springframework.integration.kafka.support.KafkaProducerContext;
 import org.springframework.integration.kafka.support.ProducerConfiguration;
 import org.springframework.integration.kafka.support.ProducerMetadata;
+import org.springframework.integration.kafka.util.EncoderAdaptingSerializer;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -45,7 +52,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
-public class KafkaProducerContextParserTests<K,V,T> {
+public class KafkaProducerContextParserTests {
 
 	@ClassRule
 	public static KafkaRunning kafkaRunning = KafkaRunning.isRunning();
@@ -54,39 +61,78 @@ public class KafkaProducerContextParserTests<K,V,T> {
 	private ApplicationContext appContext;
 
 	@Test
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({"unchecked","rawtypes"})
 	public void testProducerContextConfiguration(){
-		final KafkaProducerContext<K,V> producerContext = appContext.getBean("producerContext", KafkaProducerContext.class);
+		final KafkaProducerContext producerContext = appContext.getBean("producerContext", KafkaProducerContext.class);
 		Assert.assertNotNull(producerContext);
 
-		final Map<String, ProducerConfiguration<K,V>> producerConfigurations = producerContext.getProducerConfigurations();
-		Assert.assertEquals(producerConfigurations.size(), 2);
+		final Map<String, ProducerConfiguration<?,?>> producerConfigurations = producerContext.getProducerConfigurations();
+		assertEquals(producerConfigurations.size(), 2);
 
-		final ProducerConfiguration<K,V> producerConfigurationTest1 = producerConfigurations.get("test1");
+		final ProducerConfiguration<?,?> producerConfigurationTest1 = producerConfigurations.get("test1");
 		Assert.assertNotNull(producerConfigurationTest1);
-		final ProducerMetadata<K,V> producerMetadataTest1 = producerConfigurationTest1.getProducerMetadata();
-		Assert.assertEquals(producerMetadataTest1.getTopic(), "test1");
-		Assert.assertEquals(producerMetadataTest1.getCompressionCodec(), "0");
-		Assert.assertEquals(producerMetadataTest1.getKeyClassType(), java.lang.String.class);
-		Assert.assertEquals(producerMetadataTest1.getValueClassType(), java.lang.String.class);
+		final ProducerMetadata<?,?> producerMetadataTest1 = producerConfigurationTest1.getProducerMetadata();
+		assertEquals(producerMetadataTest1.getTopic(), "test1");
+		assertEquals(producerMetadataTest1.getCompressionType(), ProducerMetadata.CompressionType.none);
+		assertEquals(producerMetadataTest1.getKeyClassType(), java.lang.String.class);
+		assertEquals(producerMetadataTest1.getValueClassType(), java.lang.String.class);
 
-		final Encoder<T> valueEncoder = appContext.getBean("valueEncoder", Encoder.class);
-		Assert.assertEquals(producerMetadataTest1.getValueEncoder(), valueEncoder);
-		Assert.assertEquals(producerMetadataTest1.getKeyEncoder(), valueEncoder);
+		final Encoder<?> valueEncoder = appContext.getBean("valueEncoder", Encoder.class);
+		Assert.assertThat((Class) producerMetadataTest1.getKeySerializer().getClass(), equalTo((Class) EncoderAdaptingSerializer.class));
+		Assert.assertThat(((EncoderAdaptingSerializer) producerMetadataTest1.getKeySerializer()).getEncoder(), equalTo((Encoder) valueEncoder));
+		Assert.assertThat((Class)producerMetadataTest1.getValueSerializer().getClass(), equalTo((Class)EncoderAdaptingSerializer.class));
+		Assert.assertThat(((EncoderAdaptingSerializer)producerMetadataTest1.getValueSerializer()).getEncoder(), equalTo((Encoder)valueEncoder));
 
-		final Producer<K,V> producerTest1 = producerConfigurationTest1.getProducer();
-		Assert.assertEquals(producerConfigurationTest1, new ProducerConfiguration<K,V>(producerMetadataTest1, producerTest1));
+		DirectFieldAccessor directFieldAccessor = new DirectFieldAccessor(producerConfigurationTest1);
+		Producer<?,?> producerTest1 = (Producer<?, ?>) directFieldAccessor.getPropertyValue("producer");
+		assertEquals(producerConfigurationTest1.getProducerMetadata(), producerMetadataTest1);
 
-		final ProducerConfiguration<K,V> producerConfigurationTest2 = producerConfigurations.get("test2");
+		final ProducerConfiguration<?,?> producerConfigurationTest2 = producerConfigurations.get("test2");
 		Assert.assertNotNull(producerConfigurationTest2);
-		final ProducerMetadata<K,V> producerMetadataTest2 = producerConfigurationTest2.getProducerMetadata();
-		Assert.assertEquals(producerMetadataTest2.getTopic(), "test2");
-		Assert.assertEquals(producerMetadataTest2.getCompressionCodec(), "0");
+		final ProducerMetadata<?,?> producerMetadataTest2 = producerConfigurationTest2.getProducerMetadata();
+		assertEquals(producerMetadataTest2.getTopic(), "test2");
+		assertEquals(producerMetadataTest2.getCompressionType(), ProducerMetadata.CompressionType.none);
 
-		final Producer<K,V> producerTest2 = producerConfigurationTest2.getProducer();
-		Assert.assertEquals(producerConfigurationTest2, new ProducerConfiguration<K,V>(producerMetadataTest2, producerTest2));
+		DirectFieldAccessor directFieldAccessor2 = new DirectFieldAccessor(producerConfigurationTest2);
+		Producer<?,?> producerTest2 = (Producer<?, ?>) directFieldAccessor2.getPropertyValue("producer");
+		assertEquals(producerConfigurationTest2.getProducerMetadata(), producerMetadataTest2);
+
+		final Serializer<?> stringSerializer = appContext.getBean("stringSerializer", Serializer.class);
+		assertSame(stringSerializer, producerConfigurationTest2.getProducerMetadata().getKeySerializer());
+		assertSame(stringSerializer, producerConfigurationTest2.getProducerMetadata().getValueSerializer());
+
+		final Partitioner partitioner = appContext.getBean("partitioner", Partitioner.class);
+		assertSame(partitioner, producerConfigurationTest2.getProducerMetadata().getPartitioner());
+
+		final ConversionService conversionService = appContext.getBean("conversionService", ConversionService.class);
+		ConversionService configuredConversionService = (ConversionService) directFieldAccessor2.getPropertyValue("conversionService");
+		assertSame(conversionService, configuredConversionService);
+
+		assertEquals(9876,producerConfigurationTest2.getProducerMetadata().getBatchBytes());
 
 		assertFalse(TestUtils.getPropertyValue(producerContext, "autoStartup", Boolean.class));
 		assertEquals(123, TestUtils.getPropertyValue(producerContext, "phase"));
+	}
+
+	public static class StubConversionService implements ConversionService {
+		@Override
+		public boolean canConvert(Class<?> sourceType, Class<?> targetType) {
+			return false;
+		}
+
+		@Override
+		public boolean canConvert(TypeDescriptor sourceType, TypeDescriptor targetType) {
+			return false;
+		}
+
+		@Override
+		public <T> T convert(Object source, Class<T> targetType) {
+			return null;
+		}
+
+		@Override
+		public Object convert(Object source, TypeDescriptor sourceType, TypeDescriptor targetType) {
+			return null;
+		}
 	}
 }

--- a/src/test/java/org/springframework/integration/kafka/listener/AbstractBrokerTests.java
+++ b/src/test/java/org/springframework/integration/kafka/listener/AbstractBrokerTests.java
@@ -179,11 +179,13 @@ public abstract class AbstractBrokerTests {
 			for (ProducerRecord<K, V> record : records) {
 					lastFuture = producer.send(record);
 			}
+			// only block if there is at least one message to be sent
 			if (lastFuture != null) {
 				try {
+					// block until the last message has been sent, so we make this deterministic
 					lastFuture.get();
 				} catch (InterruptedException e) {
-					// not being able to confirm the
+					// not being able to confirm that all messages have been sent, fail the test
 					throw new RuntimeException(e);
 				} catch (ExecutionException e) {
 					throw new RuntimeException(e);

--- a/src/test/java/org/springframework/integration/kafka/listener/AbstractBrokerTests.java
+++ b/src/test/java/org/springframework/integration/kafka/listener/AbstractBrokerTests.java
@@ -20,19 +20,11 @@ import static org.springframework.integration.kafka.util.TopicUtils.ensureTopicC
 import static scala.collection.JavaConversions.asScalaBuffer;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Properties;
-
-import org.I0Itec.zkclient.ZkClient;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.junit.After;
-
-import org.springframework.integration.kafka.core.BrokerAddressListConfiguration;
-import org.springframework.integration.kafka.core.Configuration;
-import org.springframework.integration.kafka.core.ConnectionFactory;
-import org.springframework.integration.kafka.core.DefaultConnectionFactory;
-import org.springframework.integration.kafka.rule.KafkaRule;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 
 import com.gs.collections.api.RichIterable;
 import com.gs.collections.api.block.function.Function2;
@@ -41,18 +33,29 @@ import com.gs.collections.api.multimap.MutableMultimap;
 import com.gs.collections.api.tuple.Pair;
 import com.gs.collections.impl.factory.Multimaps;
 import com.gs.collections.impl.tuple.Tuples;
-
 import kafka.admin.AdminUtils;
-import kafka.producer.KeyedMessage;
-import kafka.producer.Producer;
-import kafka.producer.ProducerConfig;
-import kafka.serializer.StringEncoder;
 import kafka.utils.TestUtils;
+import org.I0Itec.zkclient.ZkClient;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.junit.After;
 import scala.collection.JavaConversions;
 import scala.collection.Map;
 import scala.collection.immutable.List$;
 import scala.collection.immutable.Map$;
 import scala.collection.immutable.Seq;
+
+import org.springframework.integration.kafka.core.BrokerAddressListConfiguration;
+import org.springframework.integration.kafka.core.Configuration;
+import org.springframework.integration.kafka.core.ConnectionFactory;
+import org.springframework.integration.kafka.core.DefaultConnectionFactory;
+import org.springframework.integration.kafka.rule.KafkaRule;
+import org.springframework.integration.kafka.serializer.common.StringEncoder;
+import org.springframework.integration.kafka.util.EncoderAdaptingSerializer;
 
 /**
  * @author Marius Bogoevici
@@ -110,26 +113,27 @@ public abstract class AbstractBrokerTests {
 		return configuration;
 	}
 
-	public static scala.collection.Seq<KeyedMessage<String, String>> createMessages(int count, String topic) {
-		return createMessagesInRange(0, count - 1, topic);
+	public static Collection<ProducerRecord<String, String>> createMessages(int count, String topic, int partitionCount) {
+		return createMessagesInRange(0, count - 1, topic, partitionCount);
 	}
 
-	public static scala.collection.Seq<KeyedMessage<String, String>> createMessagesInRange(int start, int end,
-			String topic) {
-		List<KeyedMessage<String, String>> messages = new ArrayList<KeyedMessage<String, String>>();
+	public static Collection<ProducerRecord<String, String>> createMessagesInRange(int start, int end,
+			String topic, int partitionCount) {
+		List<ProducerRecord<String, String>> messages = new ArrayList<>();
 		for (int i = start; i <= end; i++) {
-			messages.add(new KeyedMessage<String, String>(topic, "Key " + i, i, "Message " + i));
+			messages.add(new ProducerRecord<>(topic, i % partitionCount, "Key " + i, "Message " + i));
 		}
-		return asScalaBuffer(messages).toSeq();
+		return messages;
 	}
 
-	public Producer<String, String> createStringProducer(int compression) {
-		Properties producerConfig = TestUtils.getProducerConfig(getKafkaRule().getBrokersAsString(),
-				TestPartitioner.class.getCanonicalName());
-		producerConfig.put("serializer.class", StringEncoder.class.getCanonicalName());
-		producerConfig.put("key.serializer.class", StringEncoder.class.getCanonicalName());
-		producerConfig.put("compression.codec", Integer.toString(compression));
-		return new Producer<String, String>(new ProducerConfig(producerConfig));
+	public Sender<String, String> createMessageSender(String compression) {
+		Properties producerConfig = new Properties();
+		producerConfig.setProperty("bootstrap.servers", getKafkaRule().getBrokersAsString());
+		producerConfig.setProperty("compression.type", compression);
+		KafkaProducer<String, String> producer = new KafkaProducer<>(producerConfig,
+				new EncoderAdaptingSerializer<>(new StringEncoder()),
+				new EncoderAdaptingSerializer<>(new StringEncoder()));
+		return new Sender<>(producer);
 	}
 
 	public ConnectionFactory getKafkaBrokerConnectionFactory() throws Exception {
@@ -159,6 +163,32 @@ public abstract class AbstractBrokerTests {
 		}
 		catch (InterruptedException e) {
 			log.error(e);
+		}
+	}
+
+	public class Sender<K,V> {
+
+		private Producer<K,V> producer;
+
+		public Sender(Producer<K, V> producer) {
+			this.producer = producer;
+		}
+
+		public void send(Collection<ProducerRecord<K,V>> records) {
+			Future<RecordMetadata> lastFuture = null;
+			for (ProducerRecord<K, V> record : records) {
+					lastFuture = producer.send(record);
+			}
+			if (lastFuture != null) {
+				try {
+					lastFuture.get();
+				} catch (InterruptedException e) {
+					// not being able to confirm the
+					throw new RuntimeException(e);
+				} catch (ExecutionException e) {
+					throw new RuntimeException(e);
+				}
+			}
 		}
 	}
 

--- a/src/test/java/org/springframework/integration/kafka/listener/ChannelAdapterWithXmlConfigurationTests.java
+++ b/src/test/java/org/springframework/integration/kafka/listener/ChannelAdapterWithXmlConfigurationTests.java
@@ -20,8 +20,6 @@ package org.springframework.integration.kafka.listener;
 import static org.hamcrest.Matchers.notNullValue;
 
 
-import kafka.message.NoCompressionCodec$;
-
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -50,9 +48,11 @@ public class ChannelAdapterWithXmlConfigurationTests extends AbstractMessageList
 
 		System.setProperty("kafka.test.topic", TEST_TOPIC);
 
-		createTopic(TEST_TOPIC, 1, 1, 1);
+		int partitionCount = 1;
 
-		createStringProducer(NoCompressionCodec$.MODULE$.codec()).send(createMessages(100, TEST_TOPIC));
+		createTopic(TEST_TOPIC, partitionCount, 1, 1);
+
+		createMessageSender("none").send(createMessages(100, TEST_TOPIC, partitionCount));
 
 		ClassPathXmlApplicationContext context =
 				new ClassPathXmlApplicationContext("ChannelAdapterWithXmlConfigurationTests-context.xml",
@@ -65,5 +65,4 @@ public class ChannelAdapterWithXmlConfigurationTests extends AbstractMessageList
 			Assert.assertThat(received, notNullValue());
 		}
 	}
-
 }

--- a/src/test/java/org/springframework/integration/kafka/listener/DefaultConnectionTests.java
+++ b/src/test/java/org/springframework/integration/kafka/listener/DefaultConnectionTests.java
@@ -17,7 +17,7 @@
 
 package org.springframework.integration.kafka.listener;
 
-import kafka.producer.Producer;
+import org.apache.kafka.clients.producer.Producer;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -62,8 +62,7 @@ public class DefaultConnectionTests extends AbstractBrokerTests {
 	@Test
 	public void testReceiveMessages() throws Exception {
 		createTopic(TEST_TOPIC, 1, 1, 1);
-		Producer<String, String> producer = createStringProducer(0);
-		producer.send( createMessages(10, TEST_TOPIC));
+		createMessageSender("none").send(createMessages(10, TEST_TOPIC, 1));
 		Connection brokerConnection =
 				new DefaultConnection(getKafkaRule().getBrokerAddresses()[0], "client", 64*1024, 3000, 1, 10000);
 		Partition partition = new Partition(TEST_TOPIC, 0);
@@ -85,8 +84,7 @@ public class DefaultConnectionTests extends AbstractBrokerTests {
 	@Test
 	public void testReceiveMessagesWithGZipCompression() throws Exception {
 		createTopic(TEST_TOPIC, 1, 1, 1);
-		Producer<String, String> producer = createStringProducer(1);
-		producer.send( createMessages(10, TEST_TOPIC));
+		createMessageSender("gzip").send(createMessages(10, TEST_TOPIC, 1));
 		Connection brokerConnection =
 				new DefaultConnection(getKafkaRule().getBrokerAddresses()[0], "client", 64*1024, 3000, 1, 10000);
 		Partition partition = new Partition(TEST_TOPIC, 0);
@@ -108,15 +106,12 @@ public class DefaultConnectionTests extends AbstractBrokerTests {
 	@Test
 	@Ignore
 	/**
-	 * The compression codec '2' is for Snappy:
-	 * {@code producerConfig.put("compression.codec",  2);}
-	 * Since it relies on the native library we can't test it on all environment,
+	 * Since the test relies on the native library we can't test it on all environments,
 	 * because we may not have permission to load dll(so).
 	 */
 	public void testReceiveMessagesWithSnappyCompression() throws Exception {
 		createTopic(TEST_TOPIC, 1, 1, 1);
-		Producer<String, String> producer = createStringProducer(2);
-		producer.send( createMessages(10, TEST_TOPIC));
+		createMessageSender("snappy").send( createMessages(10, TEST_TOPIC,1));
 		Connection brokerConnection =
 				new DefaultConnection(getKafkaRule().getBrokerAddresses()[0], "client", 64*1024, 3000, 1, 10000);
 		Partition partition = new Partition(TEST_TOPIC, 0);

--- a/src/test/java/org/springframework/integration/kafka/listener/MultiBroker20Tests.java
+++ b/src/test/java/org/springframework/integration/kafka/listener/MultiBroker20Tests.java
@@ -40,21 +40,21 @@ public class MultiBroker20Tests extends AbstractMessageListenerContainerTests {
 	@Ignore
 	public void testLowVolumeHighConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 100, 20, 1);
-		runMessageListenerTest(100, 20, 100, 1000, 1, 0, TEST_TOPIC);
+		runMessageListenerTest(100, 20, 100, 1000, 1, "none", TEST_TOPIC);
 	}
 
 	@Test
 	@Ignore
 	public void testMediumVolumeHighConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 100, 20, 1);
-		runMessageListenerTest(100, 20, 100, 10000, 1, 0, TEST_TOPIC);
+		runMessageListenerTest(100, 20, 100, 10000, 1, "none", TEST_TOPIC);
 	}
 
 	@Test
 	@Ignore
 	public void testHighVolumeHighConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 100, 20, 1);
-		runMessageListenerTest(100, 20, 100, 100000, 1, 0, TEST_TOPIC);
+		runMessageListenerTest(100, 20, 100, 100000, 1, "none", TEST_TOPIC);
 	}
 
 }

--- a/src/test/java/org/springframework/integration/kafka/listener/MultiBroker2Tests.java
+++ b/src/test/java/org/springframework/integration/kafka/listener/MultiBroker2Tests.java
@@ -40,42 +40,42 @@ public class MultiBroker2Tests extends AbstractMessageListenerContainerTests {
 	@Test
 	public void testLowVolumeLowConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 5, 2, 1);
-		runMessageListenerTest(100, 2, 5, 100, 1, 0, TEST_TOPIC);
+		runMessageListenerTest(100, 2, 5, 100, 1, "none", TEST_TOPIC);
 	}
 
 	@Test
 	@Ignore
 	public void testMediumVolumeLowConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 5, 2, 1);
-		runMessageListenerTest(100, 2, 5, 1000, 1, 0, TEST_TOPIC);
+		runMessageListenerTest(100, 2, 5, 1000, 1, "none", TEST_TOPIC);
 	}
 
 	@Test
 	@Ignore
 	public void testHighVolumeLowConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 5, 2, 1);
-		runMessageListenerTest(100, 2, 5, 10000, 1, 0, TEST_TOPIC);
+		runMessageListenerTest(100, 2, 5, 10000, 1, "none", TEST_TOPIC);
 	}
 
 	@Test
 	@Ignore
 	public void testLowVolumeMediumConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 5, 2, 1);
-		runMessageListenerTest(100, 5, 5, 100, 1, 0, TEST_TOPIC);
+		runMessageListenerTest(100, 5, 5, 100, 1, "none", TEST_TOPIC);
 	}
 
 	@Test
 	@Ignore
 	public void testMediumVolumeMediumConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 5, 2, 1);
-		runMessageListenerTest(100, 5, 5, 1000, 1, 0, TEST_TOPIC);
+		runMessageListenerTest(100, 5, 5, 1000, 1, "none", TEST_TOPIC);
 	}
 
 	@Test
 	@Ignore
 	public void testHighVolumeMediumConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 5, 2, 1);
-		runMessageListenerTest(100, 5, 5, 100000, 1, 0, TEST_TOPIC);
+		runMessageListenerTest(100, 5, 5, 100000, 1, "none", TEST_TOPIC);
 	}
 
 
@@ -83,21 +83,21 @@ public class MultiBroker2Tests extends AbstractMessageListenerContainerTests {
 	@Ignore
 	public void testLowVolumeHighConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 100, 2, 1);
-		runMessageListenerTest(100, 20, 100, 1000, 1, 0, TEST_TOPIC);
+		runMessageListenerTest(100, 20, 100, 1000, 1, "none", TEST_TOPIC);
 	}
 
 	@Test
 	@Ignore
 	public void testMediumVolumeHighConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 100, 2, 1);
-		runMessageListenerTest(100, 20, 100, 10000, 1, 0, TEST_TOPIC);
+		runMessageListenerTest(100, 20, 100, 10000, 1, "none", TEST_TOPIC);
 	}
 
 	@Test
 	@Ignore
 	public void testHighVolumeHighConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 100, 2, 1);
-		runMessageListenerTest(100, 20, 100, 100000, 1, 0, TEST_TOPIC);
+		runMessageListenerTest(100, 20, 100, 100000, 1, "none", TEST_TOPIC);
 	}
 
 }

--- a/src/test/java/org/springframework/integration/kafka/listener/MultiBroker5ReplicatedTests.java
+++ b/src/test/java/org/springframework/integration/kafka/listener/MultiBroker5ReplicatedTests.java
@@ -39,42 +39,42 @@ public class MultiBroker5ReplicatedTests extends AbstractMessageListenerContaine
 	@Test
 	public void testLowVolumeLowConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 5, 5, 3);
-		runMessageListenerTest(100, 2, 5, 100, 1, 0, TEST_TOPIC);
+		runMessageListenerTest(100, 2, 5, 100, 1, "none", TEST_TOPIC);
 	}
 
 	@Test
 	@Ignore
 	public void testMediumVolumeLowConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 5, 5, 3);
-		runMessageListenerTest(100, 2, 5, 1000, 1, 0, TEST_TOPIC);
+		runMessageListenerTest(100, 2, 5, 1000, 1, "none", TEST_TOPIC);
 	}
 
 	@Test
 	@Ignore
 	public void testHighVolumeLowConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 5, 5, 3);
-		runMessageListenerTest(100, 2, 5, 10000, 1, 0, TEST_TOPIC);
+		runMessageListenerTest(100, 2, 5, 10000, 1, "none", TEST_TOPIC);
 	}
 
 	@Test
 	@Ignore
 	public void testLowVolumeMediumConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 5, 5, 3);
-		runMessageListenerTest(100, 5, 5, 100, 1, 0, TEST_TOPIC);
+		runMessageListenerTest(100, 5, 5, 100, 1, "none", TEST_TOPIC);
 	}
 
 	@Test
 	@Ignore
 	public void testMediumVolumeMediumConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 5, 5, 3);
-		runMessageListenerTest(100, 5, 5, 1000, 1, 0, TEST_TOPIC);
+		runMessageListenerTest(100, 5, 5, 1000, 1, "none", TEST_TOPIC);
 	}
 
 	@Test
 	@Ignore
 	public void testHighVolumeMediumConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 5, 5, 1);
-		runMessageListenerTest(100, 5, 5, 100000, 1, 0, TEST_TOPIC);
+		runMessageListenerTest(100, 5, 5, 100000, 1, "none", TEST_TOPIC);
 	}
 
 
@@ -82,21 +82,21 @@ public class MultiBroker5ReplicatedTests extends AbstractMessageListenerContaine
 	@Ignore
 	public void testLowVolumeHighConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 100, 5, 3);
-		runMessageListenerTest(100, 20, 100, 1000, 1, 0, TEST_TOPIC);
+		runMessageListenerTest(100, 20, 100, 1000, 1, "none", TEST_TOPIC);
 	}
 
 	@Test
 	@Ignore
 	public void testMediumVolumeHighConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 100, 5, 3);
-		runMessageListenerTest(100, 20, 100, 10000, 1, 0, TEST_TOPIC);
+		runMessageListenerTest(100, 20, 100, 10000, 1, "none", TEST_TOPIC);
 	}
 
 	@Test
 	@Ignore
 	public void testHighVolumeHighConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 100, 5, 3);
-		runMessageListenerTest(100, 20, 100, 100000, 1, 0, TEST_TOPIC);
+		runMessageListenerTest(100, 20, 100, 100000, 1, "none", TEST_TOPIC);
 	}
 
 }

--- a/src/test/java/org/springframework/integration/kafka/listener/MultiBroker5Tests.java
+++ b/src/test/java/org/springframework/integration/kafka/listener/MultiBroker5Tests.java
@@ -39,42 +39,42 @@ public class MultiBroker5Tests extends AbstractMessageListenerContainerTests {
 	@Test
 	public void testLowVolumeLowConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 5, 5, 1);
-		runMessageListenerTest(100, 2, 5, 100, 1, 0, TEST_TOPIC);
+		runMessageListenerTest(100, 2, 5, 100, 1, "none", TEST_TOPIC);
 	}
 
 	@Test
 	@Ignore
 	public void testMediumVolumeLowConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 5, 5, 1);
-		runMessageListenerTest(100, 2, 5, 1000, 1, 0, TEST_TOPIC);
+		runMessageListenerTest(100, 2, 5, 1000, 1, "none", TEST_TOPIC);
 	}
 
 	@Test
 	@Ignore
 	public void testHighVolumeLowConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 5, 5, 1);
-		runMessageListenerTest(100, 2, 5, 10000, 1, 0, TEST_TOPIC);
+		runMessageListenerTest(100, 2, 5, 10000, 1, "none", TEST_TOPIC);
 	}
 
 	@Test
 	@Ignore
 	public void testLowVolumeMediumConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 5, 5, 1);
-		runMessageListenerTest(100, 5, 5, 100, 1, 0, TEST_TOPIC);
+		runMessageListenerTest(100, 5, 5, 100, 1, "none", TEST_TOPIC);
 	}
 
 	@Test
 	@Ignore
 	public void testMediumVolumeMediumConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 5, 5, 1);
-		runMessageListenerTest(100, 5, 5, 1000, 1, 0, TEST_TOPIC);
+		runMessageListenerTest(100, 5, 5, 1000, 1, "none", TEST_TOPIC);
 	}
 
 	@Test
 	@Ignore
 	public void testHighVolumeMediumConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 5, 5, 1);
-		runMessageListenerTest(100, 5, 5, 100000, 1, 0, TEST_TOPIC);
+		runMessageListenerTest(100, 5, 5, 100000, 1, "none", TEST_TOPIC);
 	}
 
 
@@ -82,21 +82,21 @@ public class MultiBroker5Tests extends AbstractMessageListenerContainerTests {
 	@Ignore
 	public void testLowVolumeHighConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 100, 5, 1);
-		runMessageListenerTest(100, 20, 100, 1000, 1, 0, TEST_TOPIC);
+		runMessageListenerTest(100, 20, 100, 1000, 1, "none", TEST_TOPIC);
 	}
 
 	@Test
 	@Ignore
 	public void testMediumVolumeHighConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 100, 5, 1);
-		runMessageListenerTest(100, 20, 100, 10000, 1, 0, TEST_TOPIC);
+		runMessageListenerTest(100, 20, 100, 10000, 1, "none", TEST_TOPIC);
 	}
 
 	@Test
 	@Ignore
 	public void testHighVolumeHighConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 100, 5, 1);
-		runMessageListenerTest(100, 20, 100, 100000, 1, 0, TEST_TOPIC);
+		runMessageListenerTest(100, 20, 100, 100000, 1, "none", TEST_TOPIC);
 	}
 
 }

--- a/src/test/java/org/springframework/integration/kafka/listener/SingleBrokerExternalTests.java
+++ b/src/test/java/org/springframework/integration/kafka/listener/SingleBrokerExternalTests.java
@@ -55,7 +55,7 @@ public class SingleBrokerExternalTests extends AbstractMessageListenerContainerT
 	public void testLowVolumeLowConcurrency() throws Exception {
 		String topicName = generateTopicName();
 		createTopic(topicName, 5, 1, 1);
-		runMessageListenerTest(100, 2, 5, 100, 1, 0, topicName);
+		runMessageListenerTest(100, 2, 5, 100, 1, "none", topicName);
 		deleteTopic(topicName);
 	}
 
@@ -63,7 +63,7 @@ public class SingleBrokerExternalTests extends AbstractMessageListenerContainerT
 	public void testMediumVolumeLowConcurrency() throws Exception {
 		String topicName = generateTopicName();
 		createTopic(topicName, 5, 1, 1);
-		runMessageListenerTest(100, 2, 5, 1000, 1, 0, topicName);
+		runMessageListenerTest(100, 2, 5, 1000, 1, "none", topicName);
 		deleteTopic(topicName);
 	}
 
@@ -72,7 +72,7 @@ public class SingleBrokerExternalTests extends AbstractMessageListenerContainerT
 	public void testHighVolumeLowConcurrency() throws Exception {
 		String topicName = generateTopicName();
 		createTopic(topicName, 5, 1, 1);
-		runMessageListenerTest(100, 2, 5, 10000, 1, 0, topicName);
+		runMessageListenerTest(100, 2, 5, 10000, 1, "none", topicName);
 		deleteTopic(topicName);
 	}
 
@@ -80,7 +80,7 @@ public class SingleBrokerExternalTests extends AbstractMessageListenerContainerT
 	public void testLowVolumeMediumConcurrency() throws Exception {
 		String topicName = generateTopicName();
 		createTopic(topicName, 5, 1, 1);
-		runMessageListenerTest(100, 5, 5, 100, 1, 0, topicName);
+		runMessageListenerTest(100, 5, 5, 100, 1, "none", topicName);
 		deleteTopic(topicName);
 	}
 
@@ -88,7 +88,7 @@ public class SingleBrokerExternalTests extends AbstractMessageListenerContainerT
 	public void testMediumVolumeMediumConcurrency() throws Exception {
 		String topicName = generateTopicName();
 		createTopic(topicName, 5, 1, 1);
-		runMessageListenerTest(100, 5, 5, 1000, 1, 0, topicName);
+		runMessageListenerTest(100, 5, 5, 1000, 1, "none", topicName);
 		deleteTopic(topicName);
 	}
 
@@ -97,7 +97,7 @@ public class SingleBrokerExternalTests extends AbstractMessageListenerContainerT
 	public void testHighVolumeMediumConcurrency() throws Exception {
 		String topicName = generateTopicName();
 		createTopic(topicName, 5, 1, 1);
-		runMessageListenerTest(100, 5, 5, 100000, 1, 0, topicName);
+		runMessageListenerTest(100, 5, 5, 100000, 1, "none", topicName);
 		deleteTopic(topicName);
 	}
 
@@ -106,7 +106,7 @@ public class SingleBrokerExternalTests extends AbstractMessageListenerContainerT
 	public void testLowVolumeHighConcurrency() throws Exception {
 		String topicName = generateTopicName();
 		createTopic(topicName, 100, 1, 1);
-		runMessageListenerTest(100, 20, 100, 1000, 1, 0, topicName);
+		runMessageListenerTest(100, 20, 100, 1000, 1, "none", topicName);
 		deleteTopic(topicName);
 	}
 
@@ -115,7 +115,7 @@ public class SingleBrokerExternalTests extends AbstractMessageListenerContainerT
 	public void testMediumVolumeHighConcurrency() throws Exception {
 		String topicName = generateTopicName();
 		createTopic(topicName, 100, 1, 1);
-		runMessageListenerTest(100, 20, 100, 10000, 1, 0, topicName);
+		runMessageListenerTest(100, 20, 100, 10000, 1, "none", topicName);
 		deleteTopic(topicName);
 	}
 
@@ -124,7 +124,7 @@ public class SingleBrokerExternalTests extends AbstractMessageListenerContainerT
 	public void testHighVolumeHighConcurrency() throws Exception {
 		String topicName = generateTopicName();
 		createTopic(topicName, 100, 1, 1);
-		runMessageListenerTest(100, 20, 100, 100000, 1, 0, topicName);
+		runMessageListenerTest(100, 20, 100, 100000, 1, "none", topicName);
 		deleteTopic(topicName);
 	}
 

--- a/src/test/java/org/springframework/integration/kafka/listener/SingleBrokerRecoveryTests.java
+++ b/src/test/java/org/springframework/integration/kafka/listener/SingleBrokerRecoveryTests.java
@@ -55,7 +55,9 @@ public class SingleBrokerRecoveryTests extends AbstractMessageListenerContainerT
 
 	@Test
 	public void testCompleteShutdown() throws Exception {
-		createTopic(TEST_TOPIC, 1, 1, 1);
+		int partitionCount = 1;
+
+		createTopic(TEST_TOPIC, partitionCount, 1, 1);
 
 		ConnectionFactory connectionFactory = getKafkaBrokerConnectionFactory();
 		ArrayList<Partition> readPartitions = new ArrayList<Partition>();
@@ -68,7 +70,7 @@ public class SingleBrokerRecoveryTests extends AbstractMessageListenerContainerT
 
 		final int expectedMessageCount = 100;
 
-		createStringProducer(0).send(createMessages(10, TEST_TOPIC));
+		createMessageSender("none").send(createMessages(10, TEST_TOPIC,partitionCount));
 
 		final MutableListMultimap<Integer, KeyedMessageWithOffset> receivedData =
 				new SynchronizedPutFastListMultimap<Integer, KeyedMessageWithOffset>();
@@ -100,7 +102,7 @@ public class SingleBrokerRecoveryTests extends AbstractMessageListenerContainerT
 		kafkaEmbeddedBrokerRule.restart(0);
 
 		// now start sending messages again
-		createStringProducer(0).send(createMessages(90, TEST_TOPIC));
+		createMessageSender("none").send(createMessages(90, TEST_TOPIC,partitionCount));
 
 		latch.await(50, TimeUnit.SECONDS);
 		kafkaMessageListenerContainer.stop();
@@ -109,7 +111,7 @@ public class SingleBrokerRecoveryTests extends AbstractMessageListenerContainerT
 		assertThat(latch.getCount(), equalTo(0L));
 		System.out.println("All messages received ... checking ");
 
-		validateMessageReceipt(receivedData, 1, 1, 100, expectedMessageCount, readPartitions, 1);
+		validateMessageReceipt(receivedData, 1, partitionCount, expectedMessageCount, 1);
 
 	}
 

--- a/src/test/java/org/springframework/integration/kafka/listener/SingleBrokerTests.java
+++ b/src/test/java/org/springframework/integration/kafka/listener/SingleBrokerTests.java
@@ -39,60 +39,60 @@ public class SingleBrokerTests extends AbstractMessageListenerContainerTests {
 	@Test
 	public void testLowVolumeLowConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 5, 1, 1);
-		runMessageListenerTest(100, 2, 5, 100, 1, 0, TEST_TOPIC);
+		runMessageListenerTest(100, 2, 5, 100, 1, "none", TEST_TOPIC);
 	}
 
 	@Test
 	public void testMediumVolumeLowConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 5, 1, 1);
-		runMessageListenerTest(100, 2, 5, 1000, 1, 0, TEST_TOPIC);
+		runMessageListenerTest(100, 2, 5, 1000, 1, "none", TEST_TOPIC);
 	}
 
 	@Test
 	@Ignore
 	public void testHighVolumeLowConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 5, 1, 1);
-		runMessageListenerTest(100, 2, 5, 10000, 1, 0, TEST_TOPIC);
+		runMessageListenerTest(100, 2, 5, 10000, 1, "none", TEST_TOPIC);
 	}
 
 	@Test
 	public void testLowVolumeMediumConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 5, 1, 1);
-		runMessageListenerTest(100, 5, 5, 100, 1, 0, TEST_TOPIC);
+		runMessageListenerTest(100, 5, 5, 100, 1, "none", TEST_TOPIC);
 	}
 
 	@Test
 	public void testMediumVolumeMediumConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 5, 1, 1);
-		runMessageListenerTest(100, 5, 5, 1000, 1, 0, TEST_TOPIC);
+		runMessageListenerTest(100, 5, 5, 1000, 1, "none", TEST_TOPIC);
 	}
 
 	@Test
 	@Ignore
 	public void testHighVolumeMediumConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 5, 1, 1);
-		runMessageListenerTest(100, 5, 5, 100000, 1, 0, TEST_TOPIC);
+		runMessageListenerTest(100, 5, 5, 100000, 1, "none", TEST_TOPIC);
 	}
 
 	@Test
 	@Ignore
 	public void testLowVolumeHighConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 100, 1, 1);
-		runMessageListenerTest(100, 20, 100, 1000, 1, 0, TEST_TOPIC);
+		runMessageListenerTest(100, 20, 100, 1000, 1, "none", TEST_TOPIC);
 	}
 
 	@Test
 	@Ignore
 	public void testMediumVolumeHighConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 100, 1, 1);
-		runMessageListenerTest(100, 20, 100, 10000, 1, 0, TEST_TOPIC);
+		runMessageListenerTest(100, 20, 100, 10000, 1, "none", TEST_TOPIC);
 	}
 
 	@Test
 	@Ignore
 	public void testHighVolumeHighConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 100, 1, 1);
-		runMessageListenerTest(100, 20, 100, 100000, 1, 0, TEST_TOPIC);
+		runMessageListenerTest(100, 20, 100, 100000, 1, "none", TEST_TOPIC);
 	}
 
 }

--- a/src/test/java/org/springframework/integration/kafka/listener/SingleBrokerWithCompressionTests.java
+++ b/src/test/java/org/springframework/integration/kafka/listener/SingleBrokerWithCompressionTests.java
@@ -39,60 +39,60 @@ public class SingleBrokerWithCompressionTests extends AbstractMessageListenerCon
 	@Test
 	public void testLowVolumeLowConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 5, 1, 1);
-		runMessageListenerTest(10000, 2, 5, 100, 1, 1, TEST_TOPIC);
+		runMessageListenerTest(10000, 2, 5, 100, 1, "gzip", TEST_TOPIC);
 	}
 
 	@Test
 	public void testMediumVolumeLowConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 5, 1, 1);
-		runMessageListenerTest(10000, 2, 5, 1000, 1, 1, TEST_TOPIC);
+		runMessageListenerTest(10000, 2, 5, 1000, 1, "gzip", TEST_TOPIC);
 	}
 
 	@Test
 	@Ignore
 	public void testHighVolumeLowConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 5, 1, 1);
-		runMessageListenerTest(10000, 2, 5, 10000, 1, 1, TEST_TOPIC);
+		runMessageListenerTest(10000, 2, 5, 10000, 1, "gzip", TEST_TOPIC);
 	}
 
 	@Test
 	public void testLowVolumeMediumConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 5, 1, 1);
-		runMessageListenerTest(10000, 5, 5, 100, 1, 1, TEST_TOPIC);
+		runMessageListenerTest(10000, 5, 5, 100, 1, "gzip", TEST_TOPIC);
 	}
 
 	@Test
 	public void testMediumVolumeMediumConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 5, 1, 1);
-		runMessageListenerTest(10000, 5, 5, 1000, 1, 1, TEST_TOPIC);
+		runMessageListenerTest(10000, 5, 5, 1000, 1, "gzip", TEST_TOPIC);
 	}
 
 	@Test
 	@Ignore
 	public void testHighVolumeMediumConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 5, 1, 1);
-		runMessageListenerTest(10000, 5, 5, 100000, 1, 1, TEST_TOPIC);
+		runMessageListenerTest(10000, 5, 5, 100000, 1, "gzip", TEST_TOPIC);
 	}
 
 	@Test
 	@Ignore
 	public void testLowVolumeHighConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 100, 1, 1);
-		runMessageListenerTest(10000, 20, 100, 1000, 1, 1, TEST_TOPIC);
+		runMessageListenerTest(10000, 20, 100, 1000, 1, "gzip", TEST_TOPIC);
 	}
 
 	@Test
 	@Ignore
 	public void testMediumVolumeHighConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 100, 1, 1);
-		runMessageListenerTest(10000, 20, 100, 10000, 1, 1, TEST_TOPIC);
+		runMessageListenerTest(10000, 20, 100, 10000, 1, "gzip", TEST_TOPIC);
 	}
 
 	@Test
 	@Ignore
 	public void testHighVolumeHighConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 100, 1, 1);
-		runMessageListenerTest(10000, 20, 100, 100000, 1, 1, TEST_TOPIC);
+		runMessageListenerTest(10000, 20, 100, 100000, 1, "gzip", TEST_TOPIC);
 	}
 
 }

--- a/src/test/java/org/springframework/integration/kafka/listener/SingleBrokerWithPartitionSubsetTests.java
+++ b/src/test/java/org/springframework/integration/kafka/listener/SingleBrokerWithPartitionSubsetTests.java
@@ -39,42 +39,42 @@ public class SingleBrokerWithPartitionSubsetTests extends AbstractMessageListene
 	@Test
 	public void testLowVolumeLowConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 4, 1, 1);
-		runMessageListenerTest(100, 2, 4, 100, 2, 0, TEST_TOPIC);
+		runMessageListenerTest(100, 2, 4, 100, 2, "none", TEST_TOPIC);
 	}
 
 	@Test
 	@Ignore
 	public void testMediumVolumeLowConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 4, 1, 1);
-		runMessageListenerTest(100, 2, 4, 1000, 2, 0, TEST_TOPIC);
+		runMessageListenerTest(100, 2, 4, 1000, 2, "none", TEST_TOPIC);
 	}
 
 	@Test
 	@Ignore
 	public void testHighVolumeLowConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 4, 1, 1);
-		runMessageListenerTest(100, 2, 4, 10000, 2, 0, TEST_TOPIC);
+		runMessageListenerTest(100, 2, 4, 10000, 2, "none", TEST_TOPIC);
 	}
 
 	@Test
 	@Ignore
 	public void testLowVolumeMediumConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 10, 1, 1);
-		runMessageListenerTest(100, 5, 10, 100, 2, 0, TEST_TOPIC);
+		runMessageListenerTest(100, 5, 10, 100, 2, "none", TEST_TOPIC);
 	}
 
 	@Test
 	@Ignore
 	public void testMediumVolumeMediumConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 10, 1, 1);
-		runMessageListenerTest(100, 5, 10, 1000, 2, 0, TEST_TOPIC);
+		runMessageListenerTest(100, 5, 10, 1000, 2, "none", TEST_TOPIC);
 	}
 
 	@Test
 	@Ignore
 	public void testHighVolumeMediumConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 10, 1, 1);
-		runMessageListenerTest(100, 5, 10, 100000, 2, 0, TEST_TOPIC);
+		runMessageListenerTest(100, 5, 10, 100000, 2, "none", TEST_TOPIC);
 	}
 
 
@@ -82,21 +82,21 @@ public class SingleBrokerWithPartitionSubsetTests extends AbstractMessageListene
 	@Ignore
 	public void testLowVolumeHighConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 100, 1, 1);
-		runMessageListenerTest(100, 20, 100, 1000, 2, 0, TEST_TOPIC);
+		runMessageListenerTest(100, 20, 100, 1000, 2, "none", TEST_TOPIC);
 	}
 
 	@Test
 	@Ignore
 	public void testMediumVolumeHighConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 100, 1, 1);
-		runMessageListenerTest(100, 20, 100, 10000, 2, 0, TEST_TOPIC);
+		runMessageListenerTest(100, 20, 100, 10000, 2, "none", TEST_TOPIC);
 	}
 
 	@Test
 	@Ignore
 	public void testHighVolumeHighConcurrency() throws Exception {
 		createTopic(TEST_TOPIC, 100, 1, 1);
-		runMessageListenerTest(100, 20, 100, 100000, 2, 0, TEST_TOPIC);
+		runMessageListenerTest(100, 20, 100, 100000, 2, "none", TEST_TOPIC);
 	}
 
 

--- a/src/test/java/org/springframework/integration/kafka/offset/CodecTests.java
+++ b/src/test/java/org/springframework/integration/kafka/offset/CodecTests.java
@@ -37,9 +37,9 @@ public class CodecTests {
 
 	@Test
 	public void testKeyCodec() {
-		KafkaTopicOffsetManager.KeyEncoderDecoder codec = new KafkaTopicOffsetManager.KeyEncoderDecoder();
+		KafkaTopicOffsetManager.KeySerializerDecoder codec = new KafkaTopicOffsetManager.KeySerializerDecoder();
 
-		byte[] encodedValue = codec.toBytes(new KafkaTopicOffsetManager.Key(SOME_CONSUMER, 
+		byte[] encodedValue = codec.serialize("#unused", new KafkaTopicOffsetManager.Key(SOME_CONSUMER,
 				new Partition(SOME_TOPIC, SOME_PARTITION_ID)));
 
 		KafkaTopicOffsetManager.Key key = codec.fromBytes(encodedValue);

--- a/src/test/java/org/springframework/integration/kafka/offset/KafkaOffsetManagerTests.java
+++ b/src/test/java/org/springframework/integration/kafka/offset/KafkaOffsetManagerTests.java
@@ -16,7 +16,6 @@
 
 package org.springframework.integration.kafka.offset;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import org.springframework.integration.kafka.core.Partition;
@@ -37,8 +36,6 @@ public class KafkaOffsetManagerTests extends AbstractOffsetManagerTests {
 				"offsets-spring-test",
 				initialOffsets);
 		kafkaTopicOffsetManager.setConsumerId(consumerId);
-		// do not batch writes during tests for deterministic behaviour
-		kafkaTopicOffsetManager.setBatchWrites(false);
 		kafkaTopicOffsetManager.afterPropertiesSet();
 		kafkaTopicOffsetManager.setReferenceTimestamp(referenceTimestamp);
 		return kafkaTopicOffsetManager;

--- a/src/test/java/org/springframework/integration/kafka/support/KafkaProducerContextTests.java
+++ b/src/test/java/org/springframework/integration/kafka/support/KafkaProducerContextTests.java
@@ -18,13 +18,11 @@ package org.springframework.integration.kafka.support;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.kafka.clients.producer.Producer;
 import org.junit.Assert;
-
-import kafka.javaapi.producer.Producer;
 
 import org.junit.Test;
 import org.mockito.Mockito;
-import org.springframework.beans.factory.ListableBeanFactory;
 
 /**
  * @author Rajasekar Elango
@@ -47,7 +45,7 @@ public class KafkaProducerContextTests {
 
 		final ProducerConfiguration<String, String> producerConfiguration = new ProducerConfiguration<String, String>(producerMetadata, producer);
 
-		final Map<String, ProducerConfiguration> topicConfigurations = new HashMap<String, ProducerConfiguration>();
+		final Map<String, ProducerConfiguration<?,?>> topicConfigurations = new HashMap<String, ProducerConfiguration<?,?>>();
 		topicConfigurations.put(testRegex, producerConfiguration);
 		kafkaProducerContext.setProducerConfigurations(topicConfigurations);
 

--- a/src/test/java/org/springframework/integration/kafka/support/ProducerFactoryBeanTests.java
+++ b/src/test/java/org/springframework/integration/kafka/support/ProducerFactoryBeanTests.java
@@ -15,8 +15,9 @@
  */
 package org.springframework.integration.kafka.support;
 
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.junit.Assert;
-import kafka.javaapi.producer.Producer;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -24,41 +25,19 @@ import org.mockito.Mockito;
  * @author Soby Chacko
  * @since 0.5
  */
-public class ProducerFactoryBeanTests<K,V> {
+public class ProducerFactoryBeanTests {
 
 	@Test
 	public void createProducerWithDefaultMetadata() throws Exception {
-		final ProducerMetadata<byte[], byte[]> producerMetadata = new ProducerMetadata<byte[], byte[]>("test");
+		final ProducerMetadata<byte[], byte[]> producerMetadata = new ProducerMetadata<byte[], byte[]>("test", byte[].class, byte[].class, new ByteArraySerializer(), new ByteArraySerializer());
 		final ProducerMetadata<byte[], byte[]> tm = Mockito.spy(producerMetadata);
 		final ProducerFactoryBean<byte[], byte[]> producerFactoryBean = new ProducerFactoryBean<byte[], byte[]>(tm, "localhost:9092");
 		final Producer<byte[], byte[]> producer = producerFactoryBean.getObject();
 
 		Assert.assertTrue(producer != null);
 
-		Mockito.verify(tm, Mockito.times(1)).getPartitioner();
-		Mockito.verify(tm, Mockito.times(1)).getCompressionCodec();
-		Mockito.verify(tm, Mockito.times(1)).getValueEncoder();
-		Mockito.verify(tm, Mockito.times(1)).getKeyEncoder();
-		Mockito.verify(tm, Mockito.times(1)).isAsync();
-		Mockito.verify(tm, Mockito.times(0)).getBatchNumMessages();
-	}
-
-	@Test
-	public void createProducerWithAsyncFeatures() throws Exception {
-		final ProducerMetadata<byte[], byte[]> producerMetadata = new ProducerMetadata<byte[], byte[]>("test");
-		producerMetadata.setAsync(true);
-		producerMetadata.setBatchNumMessages("300");
-		final ProducerMetadata<byte[], byte[]> tm = Mockito.spy(producerMetadata);
-		final ProducerFactoryBean<byte[], byte[]> producerFactoryBean = new ProducerFactoryBean<byte[], byte[]>(tm, "localhost:9092");
-		final Producer<byte[], byte[]> producer = producerFactoryBean.getObject();
-
-		Assert.assertTrue(producer != null);
-
-		Mockito.verify(tm, Mockito.times(1)).getPartitioner();
-		Mockito.verify(tm, Mockito.times(1)).getCompressionCodec();
-		Mockito.verify(tm, Mockito.times(1)).getValueEncoder();
-		Mockito.verify(tm, Mockito.times(1)).getKeyEncoder();
-		Mockito.verify(tm, Mockito.times(1)).isAsync();
-		Mockito.verify(tm, Mockito.times(2)).getBatchNumMessages();
+		Mockito.verify(tm, Mockito.times(1)).getCompressionType();
+		Mockito.verify(tm, Mockito.times(1)).getValueSerializer();
+		Mockito.verify(tm, Mockito.times(1)).getKeySerializer();
 	}
 }

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -6,3 +6,4 @@ log4j.appender.stdout.layout.ConversionPattern=%d{HH:mm:ss.SSS} %-5p [%t][%c] %m
 
 log4j.category.org.springframework.integration=WARN
 log4j.category.org.springframework.integration.kafka=INFO
+log4j.category.org.apache.kafka.common.network.Selector=ERROR


### PR DESCRIPTION
- Replace producers with the new producer API
    - Change KafkaProducerContext and ProducerConfiguration to match the new Producer's behaviour (i.e. providing partition as argument)
    - support using the `partitionId` message header for targetting specific partitions;
    - allow using a SpEL expression for partitioning;
    - remove configurations that do not apply anymore, i.e. async (new producer is always async), batch size as message count, etc.
    - add new configuration options wherever necessary;
    - tweak schema - allow reuse of Encoders and Partitioners if available;

    TODO: Add missing unit tests;