### PR TITLE
INTEXT-175: Fix IEC population

### DIFF
--- a/src/test/java/org/springframework/integration/kafka/outbound/OutboundTests.java
+++ b/src/test/java/org/springframework/integration/kafka/outbound/OutboundTests.java
@@ -32,20 +32,7 @@ import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import com.gs.collections.api.multimap.MutableMultimap;
-import com.gs.collections.impl.factory.Multimaps;
-import kafka.admin.AdminUtils;
-import kafka.api.OffsetRequest;
-import kafka.common.TopicExistsException;
-import kafka.serializer.Decoder;
-import kafka.serializer.Encoder;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
-
-import org.springframework.context.expression.MapAccessor;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
-import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.integration.kafka.core.DefaultConnectionFactory;
 import org.springframework.integration.kafka.core.KafkaMessage;
 import org.springframework.integration.kafka.core.ZookeeperConfiguration;
@@ -67,11 +54,22 @@ import org.springframework.integration.kafka.util.MessageUtils;
 import org.springframework.integration.kafka.util.TopicUtils;
 import org.springframework.messaging.support.MessageBuilder;
 
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.gs.collections.api.multimap.MutableMultimap;
+import com.gs.collections.impl.factory.Multimaps;
+import kafka.admin.AdminUtils;
+import kafka.api.OffsetRequest;
+import kafka.common.TopicExistsException;
+import kafka.serializer.Decoder;
+import kafka.serializer.Encoder;
+
 /**
  * @author Gary Russell
  * @author Marius Bogoevici
  * @since 1.0
- *
  */
 public class OutboundTests {
 
@@ -136,9 +134,8 @@ public class OutboundTests {
 		SpelExpressionParser parser = new SpelExpressionParser();
 		handler.setMessageKeyExpression(parser.parseExpression("headers.foo"));
 		handler.setTopicExpression(parser.parseExpression("headers.bar"));
-		StandardEvaluationContext evaluationContext = new StandardEvaluationContext();
-		evaluationContext.addPropertyAccessor(new MapAccessor());
-		handler.setIntegrationEvaluationContext(evaluationContext);
+		handler.afterPropertiesSet();
+
 		handler.handleMessage(MessageBuilder.withPayload("bar" + suffix)
 				.setHeader("foo", "3")
 				.setHeader("bar", TOPIC)
@@ -175,7 +172,7 @@ public class OutboundTests {
 
 		final String suffix = UUID.randomUUID().toString();
 
-		KafkaMessageListenerContainer kafkaMessageListenerContainer = createMessageListenerContainer(TOPIC,TOPIC2);
+		KafkaMessageListenerContainer kafkaMessageListenerContainer = createMessageListenerContainer(TOPIC, TOPIC2);
 
 		final Decoder<String> decoder = new StringDecoder();
 
@@ -212,9 +209,8 @@ public class OutboundTests {
 		SpelExpressionParser parser = new SpelExpressionParser();
 		handler.setMessageKeyExpression(parser.parseExpression("headers.foo"));
 		handler.setTopicExpression(parser.parseExpression("headers.bar"));
-		StandardEvaluationContext evaluationContext = new StandardEvaluationContext();
-		evaluationContext.addPropertyAccessor(new MapAccessor());
-		handler.setIntegrationEvaluationContext(evaluationContext);
+		handler.afterPropertiesSet();
+
 		handler.handleMessage(MessageBuilder.withPayload("bar1" + suffix)
 				.setHeader("foo", "3")
 				.setHeader("bar", TOPIC)
@@ -278,9 +274,7 @@ public class OutboundTests {
 
 		handler.handleMessage(MessageBuilder.withPayload("fooTopic1" + suffix).build());
 
-		StandardEvaluationContext evaluationContext = new StandardEvaluationContext();
-		evaluationContext.addPropertyAccessor(new MapAccessor());
-		handler.setIntegrationEvaluationContext(evaluationContext);
+		handler.afterPropertiesSet();
 
 		producerContext.stop();
 
@@ -311,14 +305,17 @@ public class OutboundTests {
 	private KafkaProducerContext createProducerContext() throws Exception {
 		KafkaProducerContext kafkaProducerContext = new KafkaProducerContext();
 		Encoder<String> encoder = new StringEncoder();
-		ProducerMetadata<String, String> producerMetadata = new ProducerMetadata<String, String>(TOPIC, String.class, String.class, new EncoderAdaptingSerializer<String>(encoder), new EncoderAdaptingSerializer<String>(encoder));
+		ProducerMetadata<String, String> producerMetadata =
+				new ProducerMetadata<String, String>(TOPIC, String.class, String.class,
+						new EncoderAdaptingSerializer<>(encoder), new EncoderAdaptingSerializer<>(encoder));
 		Properties props = new Properties();
 		props.put("linger.ms", "15000");
 		ProducerFactoryBean<String, String> producer =
-				new ProducerFactoryBean<String, String>(producerMetadata, kafkaRule.getBrokersAsString(), props);
+				new ProducerFactoryBean<>(producerMetadata, kafkaRule.getBrokersAsString(), props);
 		ProducerConfiguration<String, String> config =
-				new ProducerConfiguration<String, String>(producerMetadata, producer.getObject());
-		Map<String, ProducerConfiguration<?, ?>> producerConfigurationMap = Collections.<String, ProducerConfiguration<?, ?>>singletonMap(TOPIC, config);
+				new ProducerConfiguration<>(producerMetadata, producer.getObject());
+		Map<String, ProducerConfiguration<?, ?>> producerConfigurationMap =
+				Collections.<String, ProducerConfiguration<?, ?>>singletonMap(TOPIC, config);
 		kafkaProducerContext.setProducerConfigurations(producerConfigurationMap);
 		return kafkaProducerContext;
 	}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INTEXT-175

Since `IntegrationEvaluationContextAware` infrastructure had had wrong design and has been deprecated in the SI-4.2, change its usage to the proper way according to the SI-core recipes.

Tested against Spring IO-2.0.