### PR TITLE
Use the latest version of the Spring IO Plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
 		maven { url 'https://repo.spring.io/plugins-release' }
 	}
 	dependencies {
-		classpath 'org.springframework.build.gradle:spring-io-plugin:0.0.3.RELEASE'
+		classpath 'io.spring.gradle:spring-io-plugin:0.0.4.RELEASE'
 	}
 }
 
@@ -17,8 +17,12 @@ apply plugin: 'idea'
 if (project.hasProperty('platformVersion')) {
 	apply plugin: 'spring-io'
 
-	dependencies {
-		springIoVersions "io.spring.platform:platform-bom:${platformVersion}@properties"
+	dependencyManagement {
+		springIoTestRuntime {
+			imports {
+				mavenBom "io.spring.platform:platform-bom:${platformVersion}"
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
This change is necessary to allow Spring IO Platform 2.0 to remove the platform-versions properties file that was deprecated in 1.1. To allow Spring Integration Kafka's Platform compliance to be verified as part of Spring IO Platform 2.0's build and release process, I'd like this to be included in Spring Integration Kafka 1.2 which is the version that's currently in Spring IO Platform 2.0. If you have any questions, please let me know.