### PR TITLE
convertPayloadIfNecessary change to use Value Class Type

### DIFF
--- a/src/main/java/org/springframework/integration/kafka/support/ProducerConfiguration.java
+++ b/src/main/java/org/springframework/integration/kafka/support/ProducerConfiguration.java
@@ -103,7 +103,7 @@ public class ProducerConfiguration<K, V> {
 
 	private V convertPayloadIfNecessary(Object messagePayload) {
 		if (messagePayload != null) {
-			if (getProducerMetadata().getKeyClassType().isAssignableFrom(
+			if (getProducerMetadata().getValueClassType().isAssignableFrom(
 					messagePayload.getClass())) {
 				return getProducerMetadata().getValueClassType().cast(messagePayload);
 			}


### PR DESCRIPTION
The `convertPayloadIfNecessary` is using `getProducerMetadata().getKeyClassType()` when it should use `getProducerMetadata().getValueClassType()`