### PR TITLE
Support for sending messages synchronously to the Kafka broker.

### DIFF
--- a/src/main/java/org/springframework/integration/kafka/config/xml/KafkaProducerContextParser.java
+++ b/src/main/java/org/springframework/integration/kafka/config/xml/KafkaProducerContextParser.java
@@ -127,6 +127,11 @@ public class KafkaProducerContextParser extends AbstractSimpleBeanDefinitionPars
 					"compression-type");
 			IntegrationNamespaceUtils.setValueIfAttributeDefined(producerMetadataBuilder, producerConfiguration,
 					"batch-bytes");
+			IntegrationNamespaceUtils.setValueIfAttributeDefined(producerMetadataBuilder, producerConfiguration,
+					"sync");
+			IntegrationNamespaceUtils.setValueIfAttributeDefined(producerMetadataBuilder, producerConfiguration,
+					"send-timeout");
+
 			AbstractBeanDefinition producerMetadataBeanDefinition = producerMetadataBuilder.getBeanDefinition();
 
 			String producerPropertiesBean = parentElem.getAttribute("producer-properties");

--- a/src/main/java/org/springframework/integration/kafka/support/ProducerMetadata.java
+++ b/src/main/java/org/springframework/integration/kafka/support/ProducerMetadata.java
@@ -49,6 +49,10 @@ public class ProducerMetadata<K,V> {
 
 	private int batchBytes = 16384;
 
+	private int sendTimeout = 0;
+
+	private boolean sync;
+
 	public ProducerMetadata(final String topic, Class<K> keyClassType, Class<V> valueClassType,
 	                        Serializer<K> keySerializer, Serializer<V> valueSerializer) {
 		Assert.notNull(topic, "Topic cannot be null");
@@ -109,6 +113,22 @@ public class ProducerMetadata<K,V> {
 		return valueClassType;
 	}
 
+	public int getSendTimeout() {
+		return sendTimeout;
+	}
+
+	public void setSendTimeout(int sendTimeout) {
+		this.sendTimeout = sendTimeout;
+	}
+
+	public boolean isSync() {
+		return sync;
+	}
+
+	public void setSync(boolean sync) {
+		this.sync = sync;
+	}
+
 	@Override
 	public String toString() {
 		return "ProducerMetadata{" +
@@ -120,6 +140,8 @@ public class ProducerMetadata<K,V> {
 				", partitioner=" + this.partitioner +
 				", compressionType=" + this.compressionType +
 				", batchBytes=" + this.batchBytes +
+				", sync=" + this.sync +
+				", sendTimeout=" + this.sendTimeout +
 				'}';
 	}
 
@@ -128,5 +150,4 @@ public class ProducerMetadata<K,V> {
 		gzip,
 		snappy
 	}
-
 }

--- a/src/main/resources/org/springframework/integration/config/xml/spring-integration-kafka-1.2.xsd
+++ b/src/main/resources/org/springframework/integration/config/xml/spring-integration-kafka-1.2.xsd
@@ -215,6 +215,20 @@
 											</xsd:documentation>
 										</xsd:annotation>
 									</xsd:attribute>
+									<xsd:attribute name="sync" use="optional" type="xsd:boolean">
+										<xsd:annotation>
+											<xsd:documentation>
+												If true, sends messages synchronously. Asynchronously (default) otherwise
+											</xsd:documentation>
+										</xsd:annotation>
+									</xsd:attribute>
+									<xsd:attribute name="send-timeout" use="optional" type="xsd:string">
+										<xsd:annotation>
+											<xsd:documentation>
+												If sync=true, specify timeout in milliseconds. 0 or below indicate forever (default)
+											</xsd:documentation>
+										</xsd:annotation>
+									</xsd:attribute>
 								</xsd:complexType>
 							</xsd:element>
 						</xsd:choice>


### PR DESCRIPTION
Adds two fields to the producer-configuration that allows to set the send mode (async or sync) and an optional timeout in sync mode. Default behavior is async.
This allows for an upstream application to verify that the message have been handed off to Kafka following the delivery options specified, and not just residing in memory at the producer.