### PR TITLE
wait topic is up INTEXT-204

### DIFF
--- a/src/main/java/org/springframework/integration/kafka/listener/MetadataStoreOffsetManager.java
+++ b/src/main/java/org/springframework/integration/kafka/listener/MetadataStoreOffsetManager.java
@@ -78,7 +78,8 @@ public class MetadataStoreOffsetManager extends AbstractOffsetManager {
 		this.metadataStore.remove(generateKey(partition));
 	}
 
-	protected Long doGetOffset(Partition partition) {
+	@Override
+    protected Long doGetOffset(Partition partition) {
 		String storedOffsetValueAsString = this.metadataStore.get(generateKey(partition));
 		Long storedOffsetValue = null;
 		if (storedOffsetValueAsString != null) {

--- a/src/test/java/org/springframework/integration/kafka/listener/AbstractBrokerTests.java
+++ b/src/test/java/org/springframework/integration/kafka/listener/AbstractBrokerTests.java
@@ -75,6 +75,7 @@ public abstract class AbstractBrokerTests {
 
 	public void createTopic(String topicName, int partitionCount, int brokers, int replication) {
 		createTopic(getKafkaRule().getZkClient(), topicName, partitionCount, brokers, replication);
+		sleep(6000);
 	}
 
 	@SuppressWarnings("unchecked")


### PR DESCRIPTION
Running all test about SingleBrokerWithCompressionTests some test fail cause at the moment of assert topic is not running and 
retrive the following exception
[main][org.springframework.integration.kafka.core.DefaultConnectionFactory] No metadata could be retrieved for 'test-topic'
kafka.common.LeaderNotAvailableException
at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
at java.lang.reflect.Constructor.newInstance(Constructor.java:408)
Running individually the test not fail
Waiting broker is up they works