### PR TITLE
Adds support for ProducerListener

### DIFF
--- a/src/main/java/org/springframework/integration/kafka/config/xml/KafkaProducerContextParser.java
+++ b/src/main/java/org/springframework/integration/kafka/config/xml/KafkaProducerContextParser.java
@@ -157,6 +157,8 @@ public class KafkaProducerContextParser extends AbstractSimpleBeanDefinitionPars
 							.addConstructorArgValue(producerFactoryBeanDefinition);
 			IntegrationNamespaceUtils.setReferenceIfAttributeDefined(producerConfigurationBuilder, producerConfiguration,
 					"conversion-service");
+			IntegrationNamespaceUtils.setReferenceIfAttributeDefined(producerConfigurationBuilder, producerConfiguration,
+					"producer-listener");
 			producerConfigurationsMap.put(producerConfiguration.getAttribute("topic"),
 					producerConfigurationBuilder.getBeanDefinition());
 		}

--- a/src/main/java/org/springframework/integration/kafka/support/DefaultProducerListener.java
+++ b/src/main/java/org/springframework/integration/kafka/support/DefaultProducerListener.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.kafka.support;
+
+import org.apache.kafka.clients.producer.RecordMetadata;
+
+/**
+ * No-op implementation of @link ProducerListener}, to be used as base class for other implementations.
+ *
+ * @author Marius Bogoevici
+ * @since 1.3
+ */
+public class DefaultProducerListener implements ProducerListener {
+
+	@Override
+	public void onSuccess(String topic, Integer partition, Object key, Object value, RecordMetadata recordMetadata) {
+	}
+
+	@Override
+	public void onError(String topic, Integer partition, Object key, Object value, Exception exception) {
+	}
+}

--- a/src/main/java/org/springframework/integration/kafka/support/LoggingProducerListener.java
+++ b/src/main/java/org/springframework/integration/kafka/support/LoggingProducerListener.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.kafka.support;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.util.ObjectUtils;
+
+/**
+ * {@link ProducerListener} that logs exceptions thrown when sending messages.
+ *
+ * @author Marius Bogoevici
+ * @since 1.3
+ */
+public class LoggingProducerListener extends DefaultProducerListener {
+
+	private static final Log log = LogFactory.getLog(LoggingProducerListener.class);
+
+	private boolean includeContents = true;
+
+	private int maxContentLogged = 100;
+
+	/**
+	 * Whether the log message should include the contents (key and payload).
+	 *
+	 * @param includeContents true if the contents of the message should be logged
+	 */
+	public void setIncludeContents(boolean includeContents) {
+		this.includeContents = includeContents;
+	}
+
+	/**
+	 * The maximum amount of data to be logged for either key or password. As message sizes may vary and
+	 * become fairly large, this allows limiting the amount of data sent to logs.
+	 *
+	 * @param maxContentLogged the maximum amount of data being logged.
+	 */
+	public void setMaxContentLogged(int maxContentLogged) {
+		this.maxContentLogged = maxContentLogged;
+	}
+
+	@Override
+	public void onError(String topic, Integer partition, Object key, Object payload, Exception exception) {
+		// key and payload are intentionally left out, due to security and/or size concerns
+		if (log.isErrorEnabled()) {
+			StringBuffer logOutput = new StringBuffer();
+			logOutput.append("Exception thrown when sending a message");
+			if (includeContents) {
+				logOutput.append(" with key='"
+						+ toDisplayString(ObjectUtils.nullSafeToString(key), maxContentLogged) + "'");
+				logOutput.append(" and payload='"
+						+ toDisplayString(ObjectUtils.nullSafeToString(payload),maxContentLogged) + "'");
+			}
+			logOutput.append(" to topic " + topic);
+			if (partition != null) {
+				logOutput.append(" and partition " +partition);
+			}
+			logOutput.append(":");
+			log.error(logOutput, exception);
+		}
+	}
+
+	private String toDisplayString(String original, int maxCharacters) {
+		if (original.length() <= maxCharacters) {
+			return original;
+		}
+		return original.substring(0, maxCharacters) + "...";
+	}
+}

--- a/src/main/java/org/springframework/integration/kafka/support/ProducerListener.java
+++ b/src/main/java/org/springframework/integration/kafka/support/ProducerListener.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.kafka.support;
+
+import org.apache.kafka.clients.producer.RecordMetadata;
+
+/**
+ * Listener for handling outbound Kafka messages. Exactly one of its methods will be invoked, depending on whether
+ * the write has been acknowledged or not.
+ *
+ * Its main goal is to provide a stateless singleton delegate for {@link org.apache.kafka.clients.producer.Callback}s,
+ * which, in all but the most trivial cases, requires creating a separate instance per message.
+ *
+ * @see org.apache.kafka.clients.producer.Callback
+ * @author Marius Bogoevici
+ * @since 1.3
+ */
+public interface ProducerListener {
+
+	/**
+	 * Invoked after the successful send of a message (that is, after it has been acknowledged by the broker)
+	 *
+	 * @param topic the destination topic
+	 * @param partition the destination partition (could be null)
+	 * @param key the key of the outbound message
+	 * @param value the payload of the outbound message
+	 * @param recordMetadata the result of the successful send operation
+	 */
+	void onSuccess(String topic, Integer partition, Object key, Object value, RecordMetadata recordMetadata);
+
+	/**
+	 * Invoked after an attempt to send a message has failed
+	 *
+	 * @param topic the destination topic
+	 * @param partition the destination partition (could be null)
+	 * @param key the key of the outbound message
+	 * @param value the payload of the outbound message
+	 * @param exception the exception thrown
+	 */
+	void onError(String topic, Integer partition, Object key, Object value,Exception exception);
+}

--- a/src/main/java/org/springframework/integration/kafka/support/ProducerListenerInvokingCallback.java
+++ b/src/main/java/org/springframework/integration/kafka/support/ProducerListenerInvokingCallback.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.kafka.support;
+
+import org.apache.kafka.clients.producer.Callback;
+import org.apache.kafka.clients.producer.RecordMetadata;
+
+import org.springframework.util.Assert;
+
+/**
+ * Adapts the {@link org.apache.kafka.clients.producer.Callback} interface of the
+ * {@link org.apache.kafka.clients.producer.Producer} to a {@link ProducerListener}.
+ *
+ * @author Marius Bogoevici
+ */
+public class ProducerListenerInvokingCallback implements Callback {
+
+	private String topic;
+
+	private Integer partition;
+
+	private Object key;
+
+	private Object payload;
+
+	private ProducerListener producerListener;
+
+	public ProducerListenerInvokingCallback(String topic, Integer partition, Object key, Object payload,
+											ProducerListener producerListener) {
+		Assert.notNull(producerListener, "must not be null");
+		this.topic = topic;
+		this.partition = partition;
+		this.key = key;
+		this.payload = payload;
+		this.producerListener = producerListener;
+	}
+
+	@Override
+	public void onCompletion(RecordMetadata metadata, Exception exception) {
+		if (exception == null) {
+			producerListener.onError(topic,partition,key, payload,exception);
+		}
+		else {
+			producerListener.onSuccess(topic, partition, key, payload, metadata);
+		}
+	}
+}

--- a/src/main/resources/org/springframework/integration/kafka/config/spring-integration-kafka-1.3.xsd
+++ b/src/main/resources/org/springframework/integration/kafka/config/spring-integration-kafka-1.3.xsd
@@ -189,6 +189,18 @@
 											</xsd:appinfo>
 										</xsd:annotation>
 									</xsd:attribute>
+									<xsd:attribute name="producer-listener" use="optional" type="xsd:string">
+										<xsd:annotation>
+											<xsd:appinfo>
+												<xsd:documentation>
+													Listener for notifying when a message has been sent or has failed.
+												</xsd:documentation>
+												<tool:annotation kind="ref">
+													<tool:expected-type type="org.springframework.integration.kafka.support.ProducerListener"/>
+												</tool:annotation>
+											</xsd:appinfo>
+										</xsd:annotation>
+									</xsd:attribute>
 									<xsd:attribute name="compression-type" use="optional" type="xsd:string">
 										<xsd:annotation>
 											<xsd:documentation><![CDATA[

--- a/src/test/java/org/springframework/integration/kafka/config/xml/KafkaProducerContextParserTests-context.xml
+++ b/src/test/java/org/springframework/integration/kafka/config/xml/KafkaProducerContextParserTests-context.xml
@@ -46,6 +46,7 @@
                                               batch-bytes="9876"
                                               partitioner="partitioner"
                                               conversion-service="conversionService"
+                                              producer-listener="producerListener"
                                            compression-type="none"/>
         </int-kafka:producer-configurations>
     </int-kafka:producer-context>
@@ -53,6 +54,8 @@
     <bean id="valueEncoder" class="org.springframework.integration.kafka.serializer.avro.AvroReflectDatumBackedKafkaEncoder">
             <constructor-arg value="java.lang.String" />
     </bean>
+
+    <bean id="producerListener" class="org.springframework.integration.kafka.support.LoggingProducerListener"/>
 
     <bean id="stringSerializer" class="org.apache.kafka.common.serialization.StringSerializer"/>
 

--- a/src/test/java/org/springframework/integration/kafka/config/xml/KafkaProducerContextParserTests.java
+++ b/src/test/java/org/springframework/integration/kafka/config/xml/KafkaProducerContextParserTests.java
@@ -36,9 +36,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.integration.kafka.rule.KafkaEmbedded;
+import org.springframework.integration.kafka.rule.KafkaRule;
 import org.springframework.integration.kafka.rule.KafkaRunning;
 import org.springframework.integration.kafka.support.KafkaProducerContext;
 import org.springframework.integration.kafka.support.ProducerConfiguration;
+import org.springframework.integration.kafka.support.ProducerListener;
 import org.springframework.integration.kafka.support.ProducerMetadata;
 import org.springframework.integration.kafka.util.EncoderAdaptingSerializer;
 import org.springframework.integration.test.util.TestUtils;
@@ -55,7 +58,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 public class KafkaProducerContextParserTests {
 
 	@ClassRule
-	public static KafkaRunning kafkaRunning = KafkaRunning.isRunning();
+	public static KafkaRule kafkaRule = new KafkaEmbedded(1);
 
 	@Autowired
 	private ApplicationContext appContext;
@@ -107,6 +110,10 @@ public class KafkaProducerContextParserTests {
 		final ConversionService conversionService = appContext.getBean("conversionService", ConversionService.class);
 		ConversionService configuredConversionService = (ConversionService) directFieldAccessor2.getPropertyValue("conversionService");
 		assertSame(conversionService, configuredConversionService);
+
+		final ProducerListener producerListener = appContext.getBean("producerListener", ProducerListener.class);
+		ProducerListener configuredProducerListener = (ProducerListener) directFieldAccessor2.getPropertyValue("producerListener");
+		assertSame(producerListener, configuredProducerListener);
 
 		assertEquals(9876,producerConfigurationTest2.getProducerMetadata().getBatchBytes());
 

--- a/src/test/java/org/springframework/integration/kafka/outbound/ProducerListenerTests.java
+++ b/src/test/java/org/springframework/integration/kafka/outbound/ProducerListenerTests.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.kafka.outbound;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.apache.kafka.clients.producer.Callback;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.Serializer;
+import org.hamcrest.CoreMatchers;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import org.springframework.beans.DirectFieldAccessor;
+import org.springframework.integration.kafka.support.KafkaHeaders;
+import org.springframework.integration.kafka.support.KafkaProducerContext;
+import org.springframework.integration.kafka.support.ProducerConfiguration;
+import org.springframework.integration.kafka.support.ProducerListener;
+import org.springframework.integration.kafka.support.ProducerListenerInvokingCallback;
+import org.springframework.integration.kafka.support.ProducerMetadata;
+import org.springframework.messaging.support.MessageBuilder;
+
+/**
+ * @author Marius Bogoevici
+ */
+public class ProducerListenerTests {
+
+	@Test
+	@SuppressWarnings({"unchecked","rawtypes"})
+	public void testProducerListenerSet() throws Exception {
+		KafkaProducerContext producerContext = new KafkaProducerContext();
+		Serializer serializer = Mockito.mock(Serializer.class);
+		ProducerMetadata<Object, Object> producerMetadata
+				= new ProducerMetadata<>("default", Object.class, Object.class, serializer, serializer);
+		Producer producer = Mockito.mock(Producer.class);
+		ProducerConfiguration<Object, Object> producerConfiguration
+				= new ProducerConfiguration<>(producerMetadata, producer);
+		ProducerListener producerListener = mock(ProducerListener.class);
+		producerConfiguration.setProducerListener(producerListener);
+		Map<String, ProducerConfiguration<?, ?>> producerConfigurations
+				= Collections.<String, ProducerConfiguration<?, ?>>singletonMap("default", producerConfiguration);
+		producerContext.setProducerConfigurations(producerConfigurations);
+		KafkaProducerMessageHandler handler = new KafkaProducerMessageHandler(producerContext);
+		handler.handleMessage(
+				MessageBuilder.withPayload("somePayload")
+						.setHeader(KafkaHeaders.PARTITION_ID, 2)
+						.setHeader(KafkaHeaders.MESSAGE_KEY, "someKey")
+						.build());
+		final ArgumentCaptor<Callback> argument = ArgumentCaptor.forClass(Callback.class);
+		verify(producer).send(any(ProducerRecord.class), argument.capture());
+		Callback callback = argument.getValue();
+		assertThat(callback, CoreMatchers.instanceOf(ProducerListenerInvokingCallback.class));
+		DirectFieldAccessor fieldAccessor = new DirectFieldAccessor(callback);
+		assertEquals(fieldAccessor.getPropertyValue("topic"),"default");
+		assertEquals(fieldAccessor.getPropertyValue("partition"),2);
+		assertEquals(fieldAccessor.getPropertyValue("key"),"someKey");
+		assertEquals(fieldAccessor.getPropertyValue("payload"),"somePayload");
+		assertSame(fieldAccessor.getPropertyValue("producerListener"), producerListener);
+		verifyNoMoreInteractions(producer);
+	}
+
+	@Test
+	@SuppressWarnings({"unchecked","rawtypes"})
+	public void testProducerListenerNotSet() throws Exception {
+		KafkaProducerContext producerContext = new KafkaProducerContext();
+		Serializer serializer = Mockito.mock(Serializer.class);
+		ProducerMetadata<Object, Object> producerMetadata
+				= new ProducerMetadata<>("default", Object.class, Object.class, serializer, serializer);
+		Producer producer = Mockito.mock(Producer.class);
+		ProducerConfiguration<Object, Object> producerConfiguration
+				= new ProducerConfiguration<>(producerMetadata, producer);
+		Map<String, ProducerConfiguration<?, ?>> producerConfigurations
+				= Collections.<String, ProducerConfiguration<?, ?>>singletonMap("default", producerConfiguration);
+		producerContext.setProducerConfigurations(producerConfigurations);
+		KafkaProducerMessageHandler handler = new KafkaProducerMessageHandler(producerContext);
+		handler.handleMessage(MessageBuilder.withPayload("somePayload").build());
+		verify(producer).send(any(ProducerRecord.class));
+		verifyNoMoreInteractions(producer);
+	}
+}


### PR DESCRIPTION
Introduces the concept of ProducerListener, that can be injected in a ProducerContext and receive notifications when a message has been acknowledged or rejected.

While the Kafka API currently supports providing a Callback, it requires the creation of a distinct instance for receiving contextual information about the message that has been sent or rejected. The newly added feature allows the use of the Callback mechanism with a configurable, injectable ProducerListener strategy.