### PR TITLE
GH-84, GH-69 Improve Partitioner deprecation note

### DIFF
--- a/src/main/java/org/springframework/integration/kafka/config/xml/KafkaConsumerContextParser.java
+++ b/src/main/java/org/springframework/integration/kafka/config/xml/KafkaConsumerContextParser.java
@@ -30,13 +30,6 @@ import org.springframework.beans.factory.support.ManagedMap;
 import org.springframework.beans.factory.xml.AbstractSingleBeanDefinitionParser;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.integration.config.xml.IntegrationNamespaceUtils;
-import org.springframework.integration.kafka.support.ConsumerConfigFactoryBean;
-import org.springframework.integration.kafka.support.ConsumerConfiguration;
-import org.springframework.integration.kafka.support.ConsumerConnectionProvider;
-import org.springframework.integration.kafka.support.ConsumerMetadata;
-import org.springframework.integration.kafka.support.KafkaConsumerContext;
-import org.springframework.integration.kafka.support.MessageLeftOverTracker;
-import org.springframework.integration.kafka.support.TopicFilterConfiguration;
 import org.springframework.util.StringUtils;
 import org.springframework.util.xml.DomUtils;
 
@@ -54,7 +47,7 @@ public class KafkaConsumerContextParser extends AbstractSingleBeanDefinitionPars
 
 	@Override
 	protected Class<?> getBeanClass(final Element element) {
-		return KafkaConsumerContext.class;
+		return org.springframework.integration.kafka.support.KafkaConsumerContext.class;
 	}
 
 	@Override
@@ -70,9 +63,9 @@ public class KafkaConsumerContextParser extends AbstractSingleBeanDefinitionPars
 		Map<String, BeanMetadataElement> consumerConfigurationsMap = new ManagedMap<String, BeanMetadataElement>();
 		for (final Element consumerConfiguration : DomUtils.getChildElementsByTagName(consumerConfigurations, "consumer-configuration")) {
 			final BeanDefinitionBuilder consumerConfigurationBuilder =
-					BeanDefinitionBuilder.genericBeanDefinition(ConsumerConfiguration.class);
+					BeanDefinitionBuilder.genericBeanDefinition(org.springframework.integration.kafka.support.ConsumerConfiguration.class);
 			final BeanDefinitionBuilder consumerMetadataBuilder =
-					BeanDefinitionBuilder.genericBeanDefinition(ConsumerMetadata.class);
+					BeanDefinitionBuilder.genericBeanDefinition(org.springframework.integration.kafka.support.ConsumerMetadata.class);
 
 			IntegrationNamespaceUtils.setValueIfAttributeDefined(consumerMetadataBuilder, consumerConfiguration,
 					"group-id");
@@ -105,7 +98,7 @@ public class KafkaConsumerContextParser extends AbstractSingleBeanDefinitionPars
 
 			if (topicFilter != null) {
 				BeanDefinition topicFilterConfigurationBeanDefinition =
-						BeanDefinitionBuilder.genericBeanDefinition(TopicFilterConfiguration.class)
+						BeanDefinitionBuilder.genericBeanDefinition(org.springframework.integration.kafka.support.TopicFilterConfiguration.class)
 								.addConstructorArgValue(topicFilter.getAttribute("pattern"))
 								.addConstructorArgValue(topicFilter.getAttribute("streams"))
 								.addConstructorArgValue(topicFilter.getAttribute("exclude"))
@@ -122,7 +115,7 @@ public class KafkaConsumerContextParser extends AbstractSingleBeanDefinitionPars
 			final String consumerPropertiesBean = parentElem.getAttribute("consumer-properties");
 
 			final BeanDefinitionBuilder consumerConfigFactoryBuilder =
-					BeanDefinitionBuilder.genericBeanDefinition(ConsumerConfigFactoryBean.class);
+					BeanDefinitionBuilder.genericBeanDefinition(org.springframework.integration.kafka.support.ConsumerConfigFactoryBean.class);
 			consumerConfigFactoryBuilder.addConstructorArgValue(consumerMetadataBeanDefintiion);
 
 			if (StringUtils.hasText(zookeeperConnectBean)) {
@@ -137,14 +130,14 @@ public class KafkaConsumerContextParser extends AbstractSingleBeanDefinitionPars
 					consumerConfigFactoryBuilder.getBeanDefinition();
 
 			BeanDefinitionBuilder consumerConnectionProviderBuilder =
-					BeanDefinitionBuilder.genericBeanDefinition(ConsumerConnectionProvider.class);
+					BeanDefinitionBuilder.genericBeanDefinition(org.springframework.integration.kafka.support.ConsumerConnectionProvider.class);
 			consumerConnectionProviderBuilder.addConstructorArgValue(consumerConfigFactoryBuilderBeanDefinition);
 
 			AbstractBeanDefinition consumerConnectionProviderBuilderBeanDefinition =
 					consumerConnectionProviderBuilder.getBeanDefinition();
 
 			BeanDefinitionBuilder messageLeftOverBeanDefinitionBuilder =
-					BeanDefinitionBuilder.genericBeanDefinition(MessageLeftOverTracker.class);
+					BeanDefinitionBuilder.genericBeanDefinition(org.springframework.integration.kafka.support.MessageLeftOverTracker.class);
 			AbstractBeanDefinition messageLeftOverBeanDefinition =
 					messageLeftOverBeanDefinitionBuilder.getBeanDefinition();
 

--- a/src/main/java/org/springframework/integration/kafka/config/xml/KafkaProducerContextParser.java
+++ b/src/main/java/org/springframework/integration/kafka/config/xml/KafkaProducerContextParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,6 +42,7 @@ import org.springframework.util.xml.DomUtils;
  * @author Soby Chacko
  * @author Ilayaperumal Gopinathan
  * @author Gary Russell
+ * @author Artem Bilan
  * @since 0.5
  */
 public class KafkaProducerContextParser extends AbstractSimpleBeanDefinitionParser {
@@ -120,7 +121,7 @@ public class KafkaProducerContextParser extends AbstractSimpleBeanDefinitionPars
 			if (StringUtils.hasText(producerConfiguration.getAttribute("partitioner"))) {
 				if (log.isWarnEnabled()) {
 					log.warn("'partitioner' is a deprecated option. Use the 'kafka_partitionId' message header or " +
-							"the partition argument in the send() or convertAndSend() methods");
+							"the 'partition-id' (or 'partition-id-expression') attribute.");
 				}
 			}
 			IntegrationNamespaceUtils.setValueIfAttributeDefined(producerMetadataBuilder, producerConfiguration,
@@ -131,6 +132,8 @@ public class KafkaProducerContextParser extends AbstractSimpleBeanDefinitionPars
 					"sync");
 			IntegrationNamespaceUtils.setValueIfAttributeDefined(producerMetadataBuilder, producerConfiguration,
 					"send-timeout");
+			IntegrationNamespaceUtils.setValueIfAttributeDefined(producerMetadataBuilder, producerConfiguration,
+					"charset");
 
 			AbstractBeanDefinition producerMetadataBeanDefinition = producerMetadataBuilder.getBeanDefinition();
 

--- a/src/main/java/org/springframework/integration/kafka/support/DefaultPartitioner.java
+++ b/src/main/java/org/springframework/integration/kafka/support/DefaultPartitioner.java
@@ -24,6 +24,7 @@ import kafka.utils.Utils;
  *
  * This class is for internal use only and therefore is at default access level
  */
+@Deprecated
 class DefaultPartitioner implements Partitioner {
 	/**
 	 * Uses the key to calculate a partition bucket id for routing

--- a/src/main/java/org/springframework/integration/kafka/support/ProducerConfiguration.java
+++ b/src/main/java/org/springframework/integration/kafka/support/ProducerConfiguration.java
@@ -26,6 +26,7 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.KafkaException;
 import org.springframework.core.convert.ConversionService;
+import org.springframework.core.convert.converter.Converter;
 import org.springframework.core.convert.support.GenericConversionService;
 import org.springframework.core.serializer.support.SerializingConverter;
 import org.springframework.util.Assert;
@@ -57,6 +58,22 @@ public class ProducerConfiguration<K, V> {
 		this.producerMetadata = producerMetadata;
 		this.producer = producer;
 		GenericConversionService genericConversionService = new GenericConversionService();
+		genericConversionService.addConverter(String.class, byte[].class, new Converter<String, byte[]>() {
+
+			@Override
+			public byte[] convert(String source) {
+				return source.getBytes(ProducerConfiguration.this.producerMetadata.getCharset());
+			}
+
+		});
+		genericConversionService.addConverter(byte[].class, String.class, new Converter<byte[], String>() {
+
+			@Override
+			public String convert(byte[] source) {
+				return new String(source, ProducerConfiguration.this.producerMetadata.getCharset());
+			}
+
+		});
 		genericConversionService.addConverter(Object.class, byte[].class, new SerializingConverter());
 		this.conversionService = genericConversionService;
 	}

--- a/src/main/java/org/springframework/integration/kafka/support/ProducerConfiguration.java
+++ b/src/main/java/org/springframework/integration/kafka/support/ProducerConfiguration.java
@@ -16,6 +16,8 @@
 
 package org.springframework.integration.kafka.support;
 
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -25,8 +27,10 @@ import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.KafkaException;
+
 import org.springframework.core.convert.ConversionService;
-import org.springframework.core.convert.converter.Converter;
+import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.core.convert.converter.GenericConverter;
 import org.springframework.core.convert.support.GenericConversionService;
 import org.springframework.core.serializer.support.SerializingConverter;
 import org.springframework.util.Assert;
@@ -58,22 +62,7 @@ public class ProducerConfiguration<K, V> {
 		this.producerMetadata = producerMetadata;
 		this.producer = producer;
 		GenericConversionService genericConversionService = new GenericConversionService();
-		genericConversionService.addConverter(String.class, byte[].class, new Converter<String, byte[]>() {
-
-			@Override
-			public byte[] convert(String source) {
-				return source.getBytes(ProducerConfiguration.this.producerMetadata.getCharset());
-			}
-
-		});
-		genericConversionService.addConverter(byte[].class, String.class, new Converter<byte[], String>() {
-
-			@Override
-			public String convert(byte[] source) {
-				return new String(source, ProducerConfiguration.this.producerMetadata.getCharset());
-			}
-
-		});
+		genericConversionService.addConverter(new StringBytesConverter());
 		genericConversionService.addConverter(Object.class, byte[].class, new SerializingConverter());
 		this.conversionService = genericConversionService;
 	}
@@ -185,6 +174,28 @@ public class ProducerConfiguration<K, V> {
 				", producerMetadata=" + this.producerMetadata +
 				", conversionService=" + this.conversionService +
 				'}';
+	}
+
+	private class StringBytesConverter implements GenericConverter {
+
+		@Override
+		public Set<ConvertiblePair> getConvertibleTypes() {
+			Set<ConvertiblePair> convertiblePairs = new HashSet<ConvertiblePair>();
+			convertiblePairs.add(new ConvertiblePair(String.class, byte[].class));
+			convertiblePairs.add(new ConvertiblePair(byte[].class, String.class));
+			return convertiblePairs;
+		}
+
+		@Override
+		public Object convert(Object source, TypeDescriptor sourceType, TypeDescriptor targetType) {
+			if (source instanceof String) {
+				return ((String) source).getBytes(ProducerConfiguration.this.producerMetadata.getCharset());
+			}
+			else {
+				return new String((byte[]) source, ProducerConfiguration.this.producerMetadata.getCharset());
+			}
+		}
+
 	}
 
 }

--- a/src/main/java/org/springframework/integration/kafka/support/ProducerMetadata.java
+++ b/src/main/java/org/springframework/integration/kafka/support/ProducerMetadata.java
@@ -16,6 +16,8 @@
 
 package org.springframework.integration.kafka.support;
 
+import java.nio.charset.Charset;
+
 import org.apache.kafka.common.serialization.Serializer;
 
 import org.springframework.util.Assert;
@@ -52,6 +54,8 @@ public class ProducerMetadata<K,V> {
 	private int sendTimeout = 0;
 
 	private boolean sync = false;
+
+	private Charset charset = Charset.forName("UTF8");
 
 	public ProducerMetadata(final String topic, Class<K> keyClassType, Class<V> valueClassType,
 	                        Serializer<K> keySerializer, Serializer<V> valueSerializer) {
@@ -129,6 +133,20 @@ public class ProducerMetadata<K,V> {
 		this.sync = sync;
 	}
 
+	public Charset getCharset() {
+		return charset;
+	}
+
+	/**
+	 * The character encoding to preform {@code String <-> byte[]} conversion
+	 * instead of general (de)serialization.
+	 * @param charset the charset encoding to use.
+	 * @since 1.3
+	 */
+	public void setCharset(Charset charset) {
+		this.charset = charset;
+	}
+
 	@Override
 	public String toString() {
 		return "ProducerMetadata{" +
@@ -142,6 +160,7 @@ public class ProducerMetadata<K,V> {
 				", batchBytes=" + this.batchBytes +
 				", sync=" + this.sync +
 				", sendTimeout=" + this.sendTimeout +
+				", charset=" + this.charset +
 				'}';
 	}
 
@@ -150,4 +169,5 @@ public class ProducerMetadata<K,V> {
 		gzip,
 		snappy
 	}
+
 }

--- a/src/main/resources/org/springframework/integration/kafka/config/spring-integration-kafka-1.3.xsd
+++ b/src/main/resources/org/springframework/integration/kafka/config/spring-integration-kafka-1.3.xsd
@@ -216,7 +216,10 @@
 										<xsd:annotation>
 											<xsd:appinfo>
 												<xsd:documentation>
+													[DEPRECATED]
 													Custom Kafka key partitioner.
+													Deprecated in favor of 'partition-id' ('partition-id-expression')
+													on the 'outbound-channel-adapter'.
 												</xsd:documentation>
 												<tool:annotation kind="ref">
 													<tool:expected-type type="kafka.producer.Partitioner"/>
@@ -242,6 +245,14 @@
 										<xsd:annotation>
 											<xsd:documentation>
 												If sync=true, specify timeout in milliseconds. 0 or below indicate forever (default)
+											</xsd:documentation>
+										</xsd:annotation>
+									</xsd:attribute>
+									<xsd:attribute name="charset" use="optional" type="xsd:string">
+										<xsd:annotation>
+											<xsd:documentation>
+												The character encoding to preform String to/from byte[] conversion
+												instead of general (de)serialization. Defaults to UTF8.
 											</xsd:documentation>
 										</xsd:annotation>
 									</xsd:attribute>

--- a/src/test/java/org/springframework/integration/kafka/config/xml/KafkaProducerContextParserTests-context.xml
+++ b/src/test/java/org/springframework/integration/kafka/config/xml/KafkaProducerContextParserTests-context.xml
@@ -44,9 +44,9 @@
                                               key-serializer="stringSerializer"
                                               value-serializer="stringSerializer"
                                               batch-bytes="9876"
-                                              partitioner="partitioner"
                                               conversion-service="conversionService"
                                               producer-listener="producerListener"
+											  charset="cp1251"
                                            compression-type="none"/>
         </int-kafka:producer-configurations>
     </int-kafka:producer-context>
@@ -59,7 +59,6 @@
 
     <bean id="stringSerializer" class="org.apache.kafka.common.serialization.StringSerializer"/>
 
-    <bean id="partitioner" class="org.springframework.integration.kafka.support.DefaultPartitioner"/>
-
     <bean id="conversionService" class="org.springframework.integration.kafka.config.xml.KafkaProducerContextParserTests.StubConversionService"/>
+
 </beans>

--- a/src/test/java/org/springframework/integration/kafka/config/xml/KafkaProducerContextParserTests.java
+++ b/src/test/java/org/springframework/integration/kafka/config/xml/KafkaProducerContextParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,8 +22,6 @@ import static org.junit.Assert.assertSame;
 
 import java.util.Map;
 
-import kafka.producer.Partitioner;
-import kafka.serializer.Encoder;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.common.serialization.Serializer;
 import org.junit.Assert;
@@ -38,7 +36,6 @@ import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.TypeDescriptor;
 import org.springframework.integration.kafka.rule.KafkaEmbedded;
 import org.springframework.integration.kafka.rule.KafkaRule;
-import org.springframework.integration.kafka.rule.KafkaRunning;
 import org.springframework.integration.kafka.support.KafkaProducerContext;
 import org.springframework.integration.kafka.support.ProducerConfiguration;
 import org.springframework.integration.kafka.support.ProducerListener;
@@ -47,6 +44,8 @@ import org.springframework.integration.kafka.util.EncoderAdaptingSerializer;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import kafka.serializer.Encoder;
 
 /**
  * @author Soby Chacko
@@ -104,9 +103,6 @@ public class KafkaProducerContextParserTests {
 		assertSame(stringSerializer, producerConfigurationTest2.getProducerMetadata().getKeySerializer());
 		assertSame(stringSerializer, producerConfigurationTest2.getProducerMetadata().getValueSerializer());
 
-		final Partitioner partitioner = appContext.getBean("partitioner", Partitioner.class);
-		assertSame(partitioner, producerConfigurationTest2.getProducerMetadata().getPartitioner());
-
 		final ConversionService conversionService = appContext.getBean("conversionService", ConversionService.class);
 		ConversionService configuredConversionService = (ConversionService) directFieldAccessor2.getPropertyValue("conversionService");
 		assertSame(conversionService, configuredConversionService);
@@ -119,6 +115,8 @@ public class KafkaProducerContextParserTests {
 
 		assertFalse(TestUtils.getPropertyValue(producerContext, "autoStartup", Boolean.class));
 		assertEquals(123, TestUtils.getPropertyValue(producerContext, "phase"));
+
+		assertEquals("windows-1251", producerConfigurationTest2.getProducerMetadata().getCharset().name());
 	}
 
 	public static class StubConversionService implements ConversionService {


### PR DESCRIPTION
Fixes GH-84 (https://github.com/spring-projects/spring-integration-kafka/issues/84)
Fixes GH-69 (https://github.com/spring-projects/spring-integration-kafka/issues/69)

* The deprecation for the `partitioner` option hasn't mentioned the `partition-id` (`partition-id-expression`) option.
* Add built-in conversion for the `String <-> byte[]` to avoid serialization for Strings
* Expose `charset` option to configure `String <-> byte[]` conversion.
* Fix `deprecation` message for the `KafkaConsumerContextParser`