### PR TITLE
INTEXT-218: Throw Exception To Caller

### DIFF
--- a/src/main/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandler.java
+++ b/src/main/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,10 @@
  */
 
 package org.springframework.integration.kafka.outbound;
+
+import java.util.concurrent.Future;
+
+import org.apache.kafka.clients.producer.RecordMetadata;
 
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.Expression;
@@ -108,7 +112,9 @@ public class KafkaProducerMessageHandler extends AbstractMessageHandler {
 				? this.messageKeyExpression.getValue(this.evaluationContext, message)
 				: message.getHeaders().get(KafkaHeaders.MESSAGE_KEY);
 
-		this.kafkaProducerContext.send(topic, partitionId, messageKey, message.getPayload());
+		Future<RecordMetadata> future = this.kafkaProducerContext.send(topic, partitionId, messageKey,
+				message.getPayload());
+		future.get();
 	}
 
 	@Override


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INTEXT-218

When the broker is down, the sending thread gets a `TimeoutException`
in its `Future`. However, the `KafkaProducerMessageHandler` discards
the `Future` without checking for an exception.


__cherry-pick to 1.3.x__