### PR TITLE
Get rid of `KafkaProducerMH.enableHeaderRouting`

### DIFF
--- a/src/main/java/org/springframework/integration/kafka/config/xml/KafkaOutboundChannelAdapterParser.java
+++ b/src/main/java/org/springframework/integration/kafka/config/xml/KafkaOutboundChannelAdapterParser.java
@@ -67,9 +67,6 @@ public class KafkaOutboundChannelAdapterParser extends AbstractOutboundChannelAd
 			kafkaProducerMessageHandlerBuilder.addPropertyValue("partitionIdExpression", partitionIdExpressionDef);
 		}
 
-		IntegrationNamespaceUtils.setValueIfAttributeDefined(kafkaProducerMessageHandlerBuilder, element,
-				"enable-header-routing");
-
 		return kafkaProducerMessageHandlerBuilder.getBeanDefinition();
 	}
 

--- a/src/main/resources/org/springframework/integration/kafka/config/spring-integration-kafka-2.0.xsd
+++ b/src/main/resources/org/springframework/integration/kafka/config/spring-integration-kafka-2.0.xsd
@@ -96,14 +96,6 @@
 							]]></xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>
-			<xsd:attribute name="enable-header-routing" type="xsd:string">
-				<xsd:annotation>
-					<xsd:documentation><![CDATA[
-								Enables the use of message headers for routing messages to specific topics and
-								partitions.
-							]]></xsd:documentation>
-				</xsd:annotation>
-			</xsd:attribute>
 			<xsd:attribute name="order">
 				<xsd:annotation>
 					<xsd:documentation>

--- a/src/test/java/org/springframework/integration/kafka/config/xml/KafkaOutboundAdapterParserTests.java
+++ b/src/test/java/org/springframework/integration/kafka/config/xml/KafkaOutboundAdapterParserTests.java
@@ -52,7 +52,6 @@ public class KafkaOutboundAdapterParserTests {
 		assertThat(TestUtils.getPropertyValue(messageHandler, "topicExpression.literalValue")).isEqualTo("foo");
 		assertThat(TestUtils.getPropertyValue(messageHandler, "messageKeyExpression.expression")).isEqualTo("'bar'");
 		assertThat(TestUtils.getPropertyValue(messageHandler, "partitionIdExpression.expression")).isEqualTo("2");
-		assertThat(TestUtils.getPropertyValue(messageHandler, "enableHeaderRouting")).isEqualTo(Boolean.TRUE);
 	}
 
 }


### PR DESCRIPTION
Since the latest Spring Kafka introduces `RECEIVED_` headers on the receiving adapter,
we don't have clashes any more with the `kafka_topic`, `kafka_partition`  headers on the producing adapter

Since we are in the `2.0` code line it is safe to just remove the `enableHeaderRouting` even if it is a breaking change.