### PR TITLE
GH-125: Introduce `sync` mode for KafkaProducerMH

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,12 +43,20 @@ repositories {
 //	maven { url 'http://repo.spring.io/libs-staging-local' }
 }
 
-sourceCompatibility = targetCompatibility = 1.7
+compileJava {
+	sourceCompatibility = 1.7
+	targetCompatibility = 1.7
+}
+
+compileTestJava {
+	sourceCompatibility = 1.8
+	targetCompatibility = 1.8
+}
 
 ext {
 	assertjVersion = '3.4.1'
 	springIntegrationVersion = '4.2.8.RELEASE'
-	springKafkaVersion = '1.0.0.RELEASE'
+	springKafkaVersion = '1.0.2.RELEASE'
 
 	idPrefix = 'kafka'
 
@@ -64,7 +72,7 @@ ext {
 eclipse.project.natures += 'org.springframework.ide.eclipse.core.springnature'
 
 jacoco {
-	toolVersion = "0.7.2.201409121644"
+	toolVersion = "0.7.7.201606060606"
 }
 
 sourceSets {

--- a/src/main/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandler.java
+++ b/src/main/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandler.java
@@ -152,7 +152,7 @@ public class KafkaProducerMessageHandler<K, V> extends AbstractMessageHandler {
 					future.get(this.sendTimeout, TimeUnit.MILLISECONDS);
 				}
 				catch (TimeoutException te) {
-					throw new MessageTimeoutException(message,"Timeout waiting for response from KafkaProducer", te);
+					throw new MessageTimeoutException(message, "Timeout waiting for response from KafkaProducer", te);
 				}
 			}
 		}

--- a/src/main/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandler.java
+++ b/src/main/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandler.java
@@ -17,9 +17,11 @@
 package org.springframework.integration.kafka.outbound;
 
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.Expression;
+import org.springframework.integration.MessageTimeoutException;
 import org.springframework.integration.expression.ExpressionUtils;
 import org.springframework.integration.handler.AbstractMessageHandler;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -146,7 +148,12 @@ public class KafkaProducerMessageHandler<K, V> extends AbstractMessageHandler {
 				future.get();
 			}
 			else {
-				future.get(this.sendTimeout, TimeUnit.MILLISECONDS);
+				try {
+					future.get(this.sendTimeout, TimeUnit.MILLISECONDS);
+				}
+				catch (TimeoutException te) {
+					throw new MessageTimeoutException(message,"Timeout waiting for response from KafkaProducer", te);
+				}
 			}
 		}
 	}

--- a/src/test/java/org/springframework/integration/kafka/config/xml/KafkaOutboundAdapterParserTests.java
+++ b/src/test/java/org/springframework/integration/kafka/config/xml/KafkaOutboundAdapterParserTests.java
@@ -17,14 +17,27 @@
 package org.springframework.integration.kafka.config.xml;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.mock;
 
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+
+import org.apache.kafka.clients.producer.MockProducer;
+import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
+import org.springframework.expression.common.LiteralExpression;
 import org.springframework.integration.kafka.outbound.KafkaProducerMessageHandler;
 import org.springframework.integration.test.util.TestUtils;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.messaging.MessageHandlingException;
+import org.springframework.messaging.support.GenericMessage;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -52,6 +65,35 @@ public class KafkaOutboundAdapterParserTests {
 		assertThat(TestUtils.getPropertyValue(messageHandler, "topicExpression.literalValue")).isEqualTo("foo");
 		assertThat(TestUtils.getPropertyValue(messageHandler, "messageKeyExpression.expression")).isEqualTo("'bar'");
 		assertThat(TestUtils.getPropertyValue(messageHandler, "partitionIdExpression.expression")).isEqualTo("2");
+	}
+
+
+	@Test
+	public void testSyncMode() {
+		MockProducer<Integer, String> mockProducer =
+				new MockProducer<>(false, new IntegerSerializer(), new StringSerializer());
+		KafkaTemplate<Integer, String> template = new KafkaTemplate<>(() -> mockProducer);
+		KafkaProducerMessageHandler<Integer, String> handler = new KafkaProducerMessageHandler<>(template);
+		handler.setBeanFactory(mock(BeanFactory.class));
+		handler.afterPropertiesSet();
+
+		handler.setSync(true);
+		handler.setTopicExpression(new LiteralExpression("foo"));
+
+		Executors.newSingleThreadExecutor()
+				.submit(() -> {
+					RuntimeException exception = new RuntimeException("Async Producer Mock exception");
+					while (!mockProducer.errorNext(exception)) {
+						Thread.sleep(100);
+					}
+					return null;
+				});
+
+		assertThatExceptionOfType(MessageHandlingException.class)
+				.isThrownBy(() -> handler.handleMessage(new GenericMessage<>("foo")))
+				.withMessageContaining("Async Producer Mock exception")
+				.withCauseExactlyInstanceOf(ExecutionException.class)
+				.withRootCauseExactlyInstanceOf(RuntimeException.class);
 	}
 
 }

--- a/src/test/java/org/springframework/integration/kafka/config/xml/KafkaOutboundAdapterParserTests.java
+++ b/src/test/java/org/springframework/integration/kafka/config/xml/KafkaOutboundAdapterParserTests.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.mock;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeoutException;
 
 import org.apache.kafka.clients.producer.MockProducer;
 import org.apache.kafka.common.serialization.IntegerSerializer;
@@ -33,6 +34,7 @@ import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.expression.common.LiteralExpression;
+import org.springframework.integration.MessageTimeoutException;
 import org.springframework.integration.kafka.outbound.KafkaProducerMessageHandler;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -94,6 +96,13 @@ public class KafkaOutboundAdapterParserTests {
 				.withMessageContaining("Async Producer Mock exception")
 				.withCauseExactlyInstanceOf(ExecutionException.class)
 				.withRootCauseExactlyInstanceOf(RuntimeException.class);
+
+		handler.setSendTimeout(1);
+
+		assertThatExceptionOfType(MessageTimeoutException.class)
+				.isThrownBy(() -> handler.handleMessage(new GenericMessage<>("foo")))
+				.withMessageContaining("Timeout waiting for response from KafkaProducer")
+				.withCauseExactlyInstanceOf(TimeoutException.class);
 	}
 
 }


### PR DESCRIPTION
Fixes: GH-125 (https://github.com/spring-projects/spring-integration-kafka/issues/125)

* Add `sync` mode for the `KafkaProducerMessageHandler` (`false` by default) to wait for result from the send `Future`
* Add `sendTimeout` do not block `Future.get()` forever
* Provide test-case based on the `MockProducer` to complete the record with an exception and verify that the `sync` mode works well
* Some dependencies upgrade