### PR TITLE
Fix XSD type for `partition-id`

### DIFF
--- a/src/main/resources/org/springframework/integration/kafka/config/spring-integration-kafka-2.0.xsd
+++ b/src/main/resources/org/springframework/integration/kafka/config/spring-integration-kafka-2.0.xsd
@@ -79,7 +79,7 @@
 							]]></xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>
-			<xsd:attribute name="partition-id" type="xsd:integer">
+			<xsd:attribute name="partition-id" type="xsd:string">
 				<xsd:annotation>
 					<xsd:documentation><![CDATA[
 								Specifies the target partition for the Kafka message.

--- a/src/test/java/org/springframework/integration/kafka/config/xml/KafkaOutboundAdapterParserTests-context.xml
+++ b/src/test/java/org/springframework/integration/kafka/config/xml/KafkaOutboundAdapterParserTests-context.xml
@@ -3,9 +3,10 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:int="http://www.springframework.org/schema/integration"
 	   xmlns:int-kafka="http://www.springframework.org/schema/integration/kafka"
+	   xmlns:context="http://www.springframework.org/schema/context"
 	   xsi:schemaLocation="http://www.springframework.org/schema/integration/kafka http://www.springframework.org/schema/integration/kafka/spring-integration-kafka.xsd
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
 
 	<int:channel id="inputToKafka" />
 
@@ -33,5 +34,11 @@
 			</bean>
 		</constructor-arg>
 	</bean>
+
+	<int-kafka:outbound-channel-adapter id="kafkaOutboundChannelAdapter2"
+										kafka-template="template"
+										auto-startup="false"
+										channel="inputToKafka"
+										partition-id="#{0}" />
 
 </beans>

--- a/src/test/java/org/springframework/integration/kafka/config/xml/KafkaOutboundAdapterParserTests.java
+++ b/src/test/java/org/springframework/integration/kafka/config/xml/KafkaOutboundAdapterParserTests.java
@@ -67,6 +67,11 @@ public class KafkaOutboundAdapterParserTests {
 		assertThat(TestUtils.getPropertyValue(messageHandler, "topicExpression.literalValue")).isEqualTo("foo");
 		assertThat(TestUtils.getPropertyValue(messageHandler, "messageKeyExpression.expression")).isEqualTo("'bar'");
 		assertThat(TestUtils.getPropertyValue(messageHandler, "partitionIdExpression.expression")).isEqualTo("'2'");
+
+		messageHandler
+				= this.appContext.getBean("kafkaOutboundChannelAdapter2.handler", KafkaProducerMessageHandler.class);
+		assertThat(messageHandler).isNotNull();
+		assertThat(TestUtils.getPropertyValue(messageHandler, "partitionIdExpression.literalValue")).isEqualTo("0");
 	}
 
 


### PR DESCRIPTION
Even if target ``partitionId` value has to be `Integer`, we want to be able to configure the attribute via property-placeholder or Bean initialization SpEL

* Change `partition-id` XSD type from `integer` -> `string`
* Ensure that fix is correct with the test-case