### PR TITLE
GH-158 - Support for timestamps in inbound and outbound messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ target
 /*.ipr
 /*.iws
 /bin/
+/classes/

--- a/README.adoc
+++ b/README.adoc
@@ -57,7 +57,9 @@ Here's an example for sending a message with an arbitrary payload and the String
             );
 ----
 
-In addition, the `<int-kafka:outbound-channel-adapter>` provides the ability to extract the key, target topic, and target partition by applying SpEL expressions on the outbound message. To that end, it supports the mutually exclusive pairs of attributes `topic`/`topic-expression`, `message-key`/`message-key-expression`, and `partition-id`/`partition-id-expression`, to allow the specification of `topic`,`message-key` and `partition-id` respectively as static values on the adapter, or to dynamically evaluate their values at runtime against the request message.
+In addition, the `<int-kafka:outbound-channel-adapter>` provides the ability to extract the key, target topic, target partition and Kafka record timestamp by applying SpEL expressions on the outbound message.
+To that end, it supports the mutually exclusive pairs of attributes `topic`/`topic-expression`, `message-key`/`message-key-expression`, and `partition-id`/`partition-id-expression`, to allow the specification of `topic`,`message-key` and `partition-id` respectively as static values on the adapter, or to dynamically evaluate their values at runtime against the request message.
+The Kafka record timestamp can be specified as a SpEL expression with an attribute name of `timestamp-expression`
 
 IMPORTANT: The `KafkaHeaders` interface (provided by `spring-kafka`) contains constants used for interacting with headers.
 The `messageKey` and `topic` default headers now require a `kafka_` prefix.
@@ -81,7 +83,8 @@ Here is an example of how the Kafka outbound channel adapter is configured with 
                                     channel="inputToKafka"
                                     topic="foo"
                                     message-key-expression="'bar'"
-                                    partition-id-expression="2">
+                                    partition-id-expression="2"
+                                    timestamp-expression="T(System).currentTimeMillis()">
 </int-kafka:outbound-channel-adapter>
 
 <bean id="template" class="org.springframework.kafka.core.KafkaTemplate">
@@ -130,7 +133,8 @@ kafkaMessageHandler(ProducerFactory<Integer, String> producerFactory, String top
                 .getHeaders()
                 .get(IntegrationMessageHeaderAccessor.SEQUENCE_NUMBER))
         .partitionId(m -> 10)
-        .topicExpression("headers[kafka_topic] ?: '" + topic + "'");
+        .topicExpression("headers[kafka_topic] ?: '" + topic + "'")
+        .timestampExpression("T(System).currentTimeMillis()");
 }
 
 ----

--- a/src/main/java/org/springframework/integration/kafka/config/xml/KafkaOutboundChannelAdapterParser.java
+++ b/src/main/java/org/springframework/integration/kafka/config/xml/KafkaOutboundChannelAdapterParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import org.springframework.integration.kafka.outbound.KafkaProducerMessageHandle
  * @author Soby Chacko
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Biju Kunjummen
  * @since 0.5
  *
  */
@@ -73,6 +74,13 @@ public class KafkaOutboundChannelAdapterParser extends AbstractOutboundChannelAd
 						"send-timeout-expression", parserContext, element, false);
 		if (sendTimeoutExpressionDef != null) {
 			kafkaProducerMessageHandlerBuilder.addPropertyValue("sendTimeoutExpression", sendTimeoutExpressionDef);
+		}
+
+		BeanDefinition timestampExpressionDef =
+				IntegrationNamespaceUtils.createExpressionDefIfAttributeDefined("timestamp-expression", element);
+
+		if (timestampExpressionDef != null) {
+			kafkaProducerMessageHandlerBuilder.addPropertyValue("timestampExpression", timestampExpressionDef);
 		}
 
 		return kafkaProducerMessageHandlerBuilder.getBeanDefinition();

--- a/src/main/java/org/springframework/integration/kafka/dsl/KafkaProducerMessageHandlerSpec.java
+++ b/src/main/java/org/springframework/integration/kafka/dsl/KafkaProducerMessageHandlerSpec.java
@@ -195,6 +195,51 @@ public class KafkaProducerMessageHandlerSpec<K, V>
 	}
 
 	/**
+	 * Configure a SpEL expression to determine the timestamp at runtime against a
+	 * request Message as a root object of evaluation context.
+	 *
+	 * @param timestampExpression the timestamp expression to use.
+	 * @return the spec.
+	 *
+	 * @since 3.0
+	 */
+	public KafkaProducerMessageHandlerSpec<K, V> timestampExpression(String timestampExpression) {
+		return this.timestampExpression(PARSER.parseExpression(timestampExpression));
+	}
+
+	/**
+	 * Configure a {@link Function} that will be invoked at run time to determine the Kafka record timestamp
+	 * will be stored in the topic. Typically used with a Java 8 Lambda expression:
+	 * <pre class="code">
+	 * {@code
+	 * .timestamp(m -> m.getHeaders().get("mytimestamp_header", Long.class))
+	 * }
+	 * </pre>
+	 * @param timestampFunction the partitionId function.
+	 * @param <P> the expected payload type.
+	 * @return the spec.
+	 *
+	 * @since 3.0
+	 */
+	public <P> KafkaProducerMessageHandlerSpec<K, V> timestamp(Function<Message<P>, Long> timestampFunction) {
+		return timestampExpression(new FunctionExpression<>(timestampFunction));
+	}
+
+	/**
+	 * Configure an {@link Expression} to determine the timestamp at runtime against a
+	 * request Message as a root object of evaluation context.
+	 * @param timestampExpression the timestamp expression to use.
+	 * @return the spec.
+	 *
+	 * @since 3.0
+	 */
+	public KafkaProducerMessageHandlerSpec<K, V> timestampExpression(Expression timestampExpression) {
+		this.target.setTimestampExpression(timestampExpression);
+		return _this();
+	}
+
+
+	/**
 	 * A {@code boolean} indicating if the {@link KafkaProducerMessageHandler}
 	 * should wait for the send operation results or not. Defaults to {@code false}.
 	 * In {@code sync} mode a downstream send operation exception will be re-thrown.

--- a/src/main/resources/org/springframework/integration/kafka/config/spring-integration-kafka-3.0.xsd
+++ b/src/main/resources/org/springframework/integration/kafka/config/spring-integration-kafka-3.0.xsd
@@ -96,6 +96,14 @@
 					]]></xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>
+			<xsd:attribute name="timestamp-expression" type="xsd:string">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+								Specifies the expression to determine the timestamp for a Kafka record
+								against the Message at runtime.
+					]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
 			<xsd:attribute name="sync">
 				<xsd:annotation>
 					<xsd:documentation><![CDATA[

--- a/src/test/java/org/springframework/integration/kafka/config/xml/KafkaOutboundAdapterParserTests-context.xml
+++ b/src/test/java/org/springframework/integration/kafka/config/xml/KafkaOutboundAdapterParserTests-context.xml
@@ -18,7 +18,9 @@
 										topic="foo"
 										message-key-expression="'bar'"
 										partition-id-expression="'2'"
-										send-timeout-expression="1000">
+										send-timeout-expression="1000"
+										timestamp-expression="T(System).currentTimeMillis()"
+	>
 		<int-kafka:request-handler-advice-chain>
 			<bean class="org.springframework.integration.handler.advice.RequestHandlerCircuitBreakerAdvice" />
 		</int-kafka:request-handler-advice-chain>

--- a/src/test/java/org/springframework/integration/kafka/config/xml/KafkaOutboundAdapterParserTests.java
+++ b/src/test/java/org/springframework/integration/kafka/config/xml/KafkaOutboundAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,6 +48,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  * @author Soby Chacko
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Biju Kunjummen
  * @since 0.5
  */
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -60,23 +61,27 @@ public class KafkaOutboundAdapterParserTests {
 
 	@Test
 	public void testOutboundAdapterConfiguration() {
-		KafkaProducerMessageHandler<?, ?> messageHandler
+		KafkaProducerMessageHandler<?, ?> messageHandler1
 			= this.appContext.getBean("kafkaOutboundChannelAdapter.handler", KafkaProducerMessageHandler.class);
-		assertThat(messageHandler).isNotNull();
-		assertThat(messageHandler.getOrder()).isEqualTo(3);
-		assertThat(TestUtils.getPropertyValue(messageHandler, "topicExpression.literalValue")).isEqualTo("foo");
-		assertThat(TestUtils.getPropertyValue(messageHandler, "messageKeyExpression.expression")).isEqualTo("'bar'");
-		assertThat(TestUtils.getPropertyValue(messageHandler, "partitionIdExpression.expression")).isEqualTo("'2'");
-		assertThat(TestUtils.getPropertyValue(messageHandler, "sync", Boolean.class)).isTrue();
-		assertThat(TestUtils.getPropertyValue(messageHandler, "sendTimeoutExpression.expression")).isEqualTo("1000");
+		assertThat(messageHandler1).isNotNull();
+		assertThat(messageHandler1.getOrder()).isEqualTo(3);
+		assertThat(TestUtils.getPropertyValue(messageHandler1, "topicExpression.literalValue")).isEqualTo("foo");
+		assertThat(TestUtils.getPropertyValue(messageHandler1, "messageKeyExpression.expression")).isEqualTo("'bar'");
+		assertThat(TestUtils.getPropertyValue(messageHandler1, "partitionIdExpression.expression")).isEqualTo("'2'");
+		assertThat(TestUtils.getPropertyValue(messageHandler1, "sync", Boolean.class)).isTrue();
+		assertThat(TestUtils.getPropertyValue(messageHandler1, "sendTimeoutExpression.expression")).isEqualTo("1000");
+		assertThat(TestUtils.getPropertyValue(messageHandler1, "timestampExpression.expression"))
+				.isEqualTo("T(System).currentTimeMillis()");
 
-		messageHandler
+		KafkaProducerMessageHandler<?, ?> messageHandler2
 				= this.appContext.getBean("kafkaOutboundChannelAdapter2.handler", KafkaProducerMessageHandler.class);
-		assertThat(messageHandler).isNotNull();
-		assertThat(TestUtils.getPropertyValue(messageHandler, "partitionIdExpression.literalValue")).isEqualTo("0");
-		assertThat(TestUtils.getPropertyValue(messageHandler, "sync", Boolean.class)).isFalse();
+		assertThat(messageHandler2).isNotNull();
+		assertThat(TestUtils.getPropertyValue(messageHandler2, "partitionIdExpression.literalValue")).isEqualTo("0");
+		assertThat(TestUtils.getPropertyValue(messageHandler2, "sync", Boolean.class)).isFalse();
 
-		assertThat(TestUtils.getPropertyValue(messageHandler, "sendTimeoutExpression.literalValue")).isEqualTo("500");
+		assertThat(TestUtils.getPropertyValue(messageHandler2, "sendTimeoutExpression.literalValue")).isEqualTo("500");
+
+
 	}
 
 

--- a/src/test/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandlerTests.java
+++ b/src/test/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.springframework.kafka.test.assertj.KafkaConditions.key;
 import static org.springframework.kafka.test.assertj.KafkaConditions.partition;
+import static org.springframework.kafka.test.assertj.KafkaConditions.timestamp;
 import static org.springframework.kafka.test.assertj.KafkaConditions.value;
 
 import org.apache.kafka.clients.consumer.Consumer;
@@ -44,8 +45,9 @@ import org.springframework.messaging.Message;
 
 /**
  * @author Gary Russell
- * @since 2.0
+ * @author Biju Kunjummen
  *
+ * @since 2.0
  */
 public class KafkaProducerMessageHandlerTests {
 
@@ -118,6 +120,30 @@ public class KafkaProducerMessageHandlerTests {
 		assertThat(record).has(key(2));
 		assertThat(record).has(partition(1));
 		assertThat(record.value()).isNull();
+	}
+
+	@Test
+	public void testOutboundWithTimestamp() {
+		ProducerFactory<Integer, String> producerFactory = new DefaultKafkaProducerFactory<>(
+				KafkaTestUtils.producerProps(embeddedKafka));
+		KafkaTemplate<Integer, String> template = new KafkaTemplate<>(producerFactory);
+		KafkaProducerMessageHandler<Integer, String> handler = new KafkaProducerMessageHandler<>(template);
+		handler.setBeanFactory(mock(BeanFactory.class));
+		handler.afterPropertiesSet();
+
+		Message<?> message = MessageBuilder.withPayload("foo")
+				.setHeader(KafkaHeaders.TOPIC, topic1)
+				.setHeader(KafkaHeaders.MESSAGE_KEY, 2)
+				.setHeader(KafkaHeaders.PARTITION_ID, 1)
+				.setHeader(KafkaHeaders.TIMESTAMP, 1487694048607L)
+				.build();
+		handler.handleMessage(message);
+
+		ConsumerRecord<Integer, String> record = KafkaTestUtils.getSingleRecord(consumer, topic1);
+		assertThat(record).has(key(2));
+		assertThat(record).has(partition(1));
+		assertThat(record).has(value("foo"));
+		assertThat(record).has(timestamp(1487694048607L));
 	}
 
 }


### PR DESCRIPTION
#158 - Support for timestamps in inbound and outbound messages

GH Issue Link - https://github.com/spring-projects/spring-integration-kafka/issues/158

Upstream Spring-Kafka issue - https://github.com/spring-projects/spring-kafka/issues/227
Upstream Spring-Kafka PR - https://github.com/spring-projects/spring-kafka/pull/241

* Added a `timestamp-expression` to outbound channel adapter schema
* Added support for specifying a timestamp expression to Kafka Java DSL

