### PR TITLE
GH-172: Add Success and Failure Message Channels

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,7 @@ ext {
 	jacksonVersion = '2.8.5'
 	log4jVersion = '2.7'
 	slf4jVersion = '1.7.22'
-	springIntegrationVersion = '4.3.11.RELEASE'
+	springIntegrationVersion = '4.3.12.BUILD-SNAPSHOT'
 	springKafkaVersion = '1.3.0.BUILD-SNAPSHOT'
 
 	idPrefix = 'kafka'

--- a/src/main/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandler.java
+++ b/src/main/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandler.java
@@ -23,22 +23,32 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 
+import org.springframework.core.AttributeAccessor;
+import org.springframework.core.AttributeAccessorSupport;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.Expression;
 import org.springframework.integration.MessageTimeoutException;
 import org.springframework.integration.expression.ExpressionUtils;
 import org.springframework.integration.expression.ValueExpression;
-import org.springframework.integration.handler.AbstractMessageHandler;
+import org.springframework.integration.handler.AbstractMessageProducingHandler;
+import org.springframework.integration.kafka.support.KafkaSendFailureException;
+import org.springframework.integration.support.DefaultErrorMessageStrategy;
+import org.springframework.integration.support.ErrorMessageStrategy;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.support.DefaultKafkaHeaderMapper;
 import org.springframework.kafka.support.JacksonPresent;
 import org.springframework.kafka.support.KafkaHeaderMapper;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.kafka.support.KafkaNull;
+import org.springframework.kafka.support.SendResult;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageHandlingException;
+import org.springframework.messaging.support.ErrorMessage;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 import org.springframework.util.concurrent.ListenableFuture;
+import org.springframework.util.concurrent.ListenableFutureCallback;
 
 /**
  * Kafka Message Handler.
@@ -54,7 +64,7 @@ import org.springframework.util.concurrent.ListenableFuture;
  *
  * @since 0.5
  */
-public class KafkaProducerMessageHandler<K, V> extends AbstractMessageHandler {
+public class KafkaProducerMessageHandler<K, V> extends AbstractMessageProducingHandler {
 
 	private static final long DEFAULT_SEND_TIMEOUT = 10000;
 
@@ -75,6 +85,18 @@ public class KafkaProducerMessageHandler<K, V> extends AbstractMessageHandler {
 	private Expression sendTimeoutExpression = new ValueExpression<>(DEFAULT_SEND_TIMEOUT);
 
 	private KafkaHeaderMapper headerMapper;
+
+	private MessageChannel sendSuccessChannel;
+
+	private String sendSuccessChannelName;
+
+	private MessageChannel sendFailureChannel;
+
+	private String sendFailureChannelName;
+
+	private boolean sendResults = true;
+
+	private ErrorMessageStrategy errorMessageStrategy = new DefaultErrorMessageStrategy();
 
 	public KafkaProducerMessageHandler(final KafkaTemplate<K, V> kafkaTemplate) {
 		Assert.notNull(kafkaTemplate, "kafkaTemplate cannot be null");
@@ -136,10 +158,13 @@ public class KafkaProducerMessageHandler<K, V> extends AbstractMessageHandler {
 	 * Specify a timeout in milliseconds for how long this
 	 * {@link KafkaProducerMessageHandler} should wait wait for send operation
 	 * results. Defaults to 10 seconds. The timeout is applied only in {@link #sync} mode.
+	 * Also applies when sending to the success or failure channels.
 	 * @param sendTimeout the timeout to wait for result fo send operation.
 	 * @since 2.0.1
 	 */
+	@Override
 	public void setSendTimeout(long sendTimeout) {
+		super.setSendTimeout(sendTimeout);
 		setSendTimeoutExpression(new ValueExpression<>(sendTimeout));
 	}
 
@@ -156,10 +181,85 @@ public class KafkaProducerMessageHandler<K, V> extends AbstractMessageHandler {
 		this.sendTimeoutExpression = sendTimeoutExpression;
 	}
 
+	/**
+	 * Set the success channel. After a successful send, the original message will be sent
+	 * to this channel.
+	 * @param sendSuccessChannel the success channel.
+	 * @since 2.1.2
+	 */
+	public void setSendSuccessChannel(MessageChannel sendSuccessChannel) {
+		this.sendSuccessChannel = sendSuccessChannel;
+	}
+
+	/**
+	 * Set the success channel name. After a successful send, the original message will be
+	 * sent to this channel name.
+	 * @param sendSuccessChannelName the success channel name.
+	 * @since 2.1.2
+	 */
+	public void setSendSuccessChannelName(String sendSuccessChannelName) {
+		this.sendSuccessChannelName = sendSuccessChannelName;
+	}
+
+	/**
+	 * Set the failure channel. After a send failure, an {@link ErrorMessage} will be sent
+	 * to this channel with a payload of a {@link MessageHandlingException} with the failed
+	 * message and cause.
+	 * @param sendFailureChannel the failure channel.
+	 * @since 2.1.2
+	 */
+	public void setSendFailureChannel(MessageChannel sendFailureChannel) {
+		this.sendFailureChannel = sendFailureChannel;
+	}
+
+	/**
+	 * Set the failure channel name. After a send failure, an {@link ErrorMessage} will be
+	 * sent to this channel name with a payload of a {@link MessageHandlingException} with
+	 * the failed message and cause.
+	 * @param sendFailureChannelName the failure channel name.
+	 */
+	public void setSendFailureChannelName(String sendFailureChannelName) {
+		this.sendFailureChannelName = sendFailureChannelName;
+	}
+
+	/**
+	 * Set the error message strategy implementation to use when sending error messages after
+	 * send failures. Cannot be null.
+	 * @param errorMessageStrategy the implementation.
+	 */
+	public void setErrorMessageStrategy(ErrorMessageStrategy errorMessageStrategy) {
+		Assert.notNull(errorMessageStrategy, "'errorMessageStrategy' cannot be null");
+		this.errorMessageStrategy = errorMessageStrategy;
+	}
+
+	protected MessageChannel getSendSuccessChannel() {
+		if (this.sendSuccessChannel != null) {
+			return this.sendSuccessChannel;
+		}
+		else if (this.sendSuccessChannelName != null) {
+			this.sendSuccessChannel = getChannelResolver().resolveDestination(this.sendSuccessChannelName);
+			return this.sendSuccessChannel;
+		}
+		return null;
+	}
+
+	protected MessageChannel getSendFailureChannel() {
+		if (this.sendFailureChannel != null) {
+			return this.sendFailureChannel;
+		}
+		else if (this.sendFailureChannelName != null) {
+			this.sendFailureChannel = getChannelResolver().resolveDestination(this.sendFailureChannelName);
+			return this.sendFailureChannel;
+		}
+		return null;
+	}
+
 	@Override
 	protected void onInit() throws Exception {
 		super.onInit();
 		this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(getBeanFactory());
+		this.sendResults = this.sendSuccessChannel != null || this.sendFailureChannel != null
+				|| this.sendSuccessChannelName != null || this.sendFailureChannelName != null;
 	}
 
 	@SuppressWarnings("unchecked")
@@ -193,9 +293,29 @@ public class KafkaProducerMessageHandler<K, V> extends AbstractMessageHandler {
 			headers = new RecordHeaders();
 			this.headerMapper.fromHeaders(message.getHeaders(), headers);
 		}
-		ProducerRecord<K, V> producerRecord = new ProducerRecord<K, V>(topic, partitionId, timestamp, (K) messageKey,
-				payload, headers);
-		ListenableFuture<?> future = this.kafkaTemplate.send(producerRecord);
+		final ProducerRecord<K, V> producerRecord = new ProducerRecord<K, V>(topic, partitionId, timestamp,
+				(K) messageKey, payload, headers);
+		ListenableFuture<SendResult<K, V>> future = this.kafkaTemplate.send(producerRecord);
+		if (this.sendResults) {
+			future.addCallback(new ListenableFutureCallback<SendResult<K, V>>() {
+
+				@Override
+				public void onSuccess(SendResult<K, V> result) {
+					if (getSendSuccessChannel() != null) {
+						KafkaProducerMessageHandler.this.messagingTemplate.send(getSendSuccessChannel(), message);
+					}
+				}
+
+				@Override
+				public void onFailure(Throwable ex) {
+					AttributeAccessor attributes = new Attributes();
+					KafkaProducerMessageHandler.this.messagingTemplate.send(getSendFailureChannel(),
+							KafkaProducerMessageHandler.this.errorMessageStrategy.buildErrorMessage(
+									new KafkaSendFailureException(message, producerRecord, ex), attributes));
+				}
+
+			});
+		}
 
 		if (this.sync) {
 			Long sendTimeout = this.sendTimeoutExpression.getValue(this.evaluationContext, message, Long.class);
@@ -216,6 +336,16 @@ public class KafkaProducerMessageHandler<K, V> extends AbstractMessageHandler {
 	@Override
 	public String getComponentType() {
 		return "kafka:outbound-channel-adapter";
+	}
+
+	// TODO: Remove this when SI 4.3.12 is available.
+	@SuppressWarnings("serial")
+	private static final class Attributes extends AttributeAccessorSupport {
+
+		Attributes() {
+			super();
+		}
+
 	}
 
 }

--- a/src/main/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandler.java
+++ b/src/main/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandler.java
@@ -41,7 +41,6 @@ import org.springframework.kafka.support.KafkaNull;
 import org.springframework.kafka.support.SendResult;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
-import org.springframework.messaging.MessageHandlingException;
 import org.springframework.messaging.support.ErrorMessage;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
@@ -175,8 +174,8 @@ public class KafkaProducerMessageHandler<K, V> extends AbstractMessageProducingH
 
 	/**
 	 * Set the failure channel. After a send failure, an {@link ErrorMessage} will be sent
-	 * to this channel with a payload of a {@link MessageHandlingException} with the failed
-	 * message and cause.
+	 * to this channel with a payload of a {@link KafkaSendFailureException} with the
+	 * failed message and cause.
 	 * @param sendFailureChannel the failure channel.
 	 * @since 2.1.2
 	 */
@@ -186,8 +185,8 @@ public class KafkaProducerMessageHandler<K, V> extends AbstractMessageProducingH
 
 	/**
 	 * Set the failure channel name. After a send failure, an {@link ErrorMessage} will be
-	 * sent to this channel name with a payload of a {@link MessageHandlingException} with
-	 * the failed message and cause.
+	 * sent to this channel name with a payload of a {@link KafkaSendFailureException}
+	 * with the failed message and cause.
 	 * @param sendFailureChannelName the failure channel name.
 	 */
 	public void setSendFailureChannelName(String sendFailureChannelName) {

--- a/src/main/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandler.java
+++ b/src/main/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandler.java
@@ -23,8 +23,6 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 
-import org.springframework.core.AttributeAccessor;
-import org.springframework.core.AttributeAccessorSupport;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.Expression;
 import org.springframework.integration.MessageTimeoutException;
@@ -308,10 +306,9 @@ public class KafkaProducerMessageHandler<K, V> extends AbstractMessageProducingH
 
 				@Override
 				public void onFailure(Throwable ex) {
-					AttributeAccessor attributes = new Attributes();
 					KafkaProducerMessageHandler.this.messagingTemplate.send(getSendFailureChannel(),
 							KafkaProducerMessageHandler.this.errorMessageStrategy.buildErrorMessage(
-									new KafkaSendFailureException(message, producerRecord, ex), attributes));
+									new KafkaSendFailureException(message, producerRecord, ex), null));
 				}
 
 			});
@@ -336,16 +333,6 @@ public class KafkaProducerMessageHandler<K, V> extends AbstractMessageProducingH
 	@Override
 	public String getComponentType() {
 		return "kafka:outbound-channel-adapter";
-	}
-
-	// TODO: Remove this when SI 4.3.12 is available.
-	@SuppressWarnings("serial")
-	private static final class Attributes extends AttributeAccessorSupport {
-
-		Attributes() {
-			super();
-		}
-
 	}
 
 }

--- a/src/main/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandler.java
+++ b/src/main/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandler.java
@@ -262,7 +262,9 @@ public class KafkaProducerMessageHandler<K, V> extends AbstractMessageProducingH
 				public void onSuccess(SendResult<K, V> result) {
 					if (getOutputChannel() != null) {
 						KafkaProducerMessageHandler.this.messagingTemplate.send(getOutputChannel(),
-								getMessageBuilderFactory().withPayload(result.getRecordMetadata()).build());
+								getMessageBuilderFactory().fromMessage(message)
+										// TODO: change to constant when available
+										.setHeader("kafka_recordMetadata", result.getRecordMetadata()).build());
 					}
 				}
 

--- a/src/main/java/org/springframework/integration/kafka/support/KafkaSendFailureException.java
+++ b/src/main/java/org/springframework/integration/kafka/support/KafkaSendFailureException.java
@@ -26,7 +26,7 @@ import org.springframework.messaging.MessagingException;
  * fails.
  *
  * @author Gary Russell
- * @since 2.1
+ * @since 2.1.2
  *
  */
 public class KafkaSendFailureException extends MessagingException {

--- a/src/main/java/org/springframework/integration/kafka/support/KafkaSendFailureException.java
+++ b/src/main/java/org/springframework/integration/kafka/support/KafkaSendFailureException.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.kafka.support;
+
+import org.apache.kafka.clients.producer.ProducerRecord;
+
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessagingException;
+
+/**
+ * An exception that is the payload of an {@code ErrorMessage} when a send
+ * fails.
+ *
+ * @author Gary Russell
+ * @since 2.1
+ *
+ */
+public class KafkaSendFailureException extends MessagingException {
+
+	private static final long serialVersionUID = 1L;
+
+	private final ProducerRecord<?, ?> record;
+
+	public KafkaSendFailureException(Message<?> message, ProducerRecord<?, ?> record, Throwable cause) {
+		super(message, cause);
+		this.record = record;
+	}
+
+	public ProducerRecord<?, ?> getRecord() {
+		return this.record;
+	}
+
+	@Override
+	public String toString() {
+		return super.toString() + " [record=" + this.record + "]";
+	}
+
+}

--- a/src/test/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandlerTests.java
+++ b/src/test/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandlerTests.java
@@ -227,7 +227,10 @@ public class KafkaProducerMessageHandlerTests {
 		assertThat(record).has(partition(1));
 		assertThat(record).has(value("foo"));
 		Message<?> received = successes.receive(10000);
-		assertThat(received.getPayload()).isInstanceOf(RecordMetadata.class);
+		assertThat(received).isNotNull();
+		assertThat(received.getPayload()).isEqualTo("foo");
+		// TODO: Change to constant when available
+		assertThat(received.getHeaders().get("kafka_recordMetadata")).isInstanceOf(RecordMetadata.class);
 
 		final RuntimeException fooException = new RuntimeException("foo");
 

--- a/src/test/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandlerTests.java
+++ b/src/test/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandlerTests.java
@@ -28,13 +28,16 @@ import java.util.Map;
 
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerRecord;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.expression.ValueExpression;
+import org.springframework.integration.kafka.support.KafkaSendFailureException;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
@@ -44,9 +47,15 @@ import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.support.DefaultKafkaHeaderMapper;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.kafka.support.KafkaNull;
+import org.springframework.kafka.support.SendResult;
 import org.springframework.kafka.test.rule.KafkaEmbedded;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.PollableChannel;
+import org.springframework.messaging.support.ErrorMessage;
+import org.springframework.util.concurrent.ListenableFuture;
+import org.springframework.util.concurrent.SettableListenableFuture;
 
 /**
  * @author Gary Russell
@@ -62,6 +71,7 @@ public class KafkaProducerMessageHandlerTests {
 
 	@ClassRule
 	public static KafkaEmbedded embeddedKafka = new KafkaEmbedded(1, true, topic1, topic2);
+
 
 	private static Consumer<Integer, String> consumer;
 
@@ -191,6 +201,61 @@ public class KafkaProducerMessageHandlerTests {
 		assertThat(record2).has(partition(1));
 		assertThat(record2).has(value("foo"));
 		assertThat(record2.timestamp()).isGreaterThanOrEqualTo(currentTimeMarker);
+	}
+
+	@Test
+	public void testOutboundWithAsyncResults() {
+		ProducerFactory<Integer, String> producerFactory = new DefaultKafkaProducerFactory<>(
+				KafkaTestUtils.producerProps(embeddedKafka));
+		KafkaTemplate<Integer, String> template = new KafkaTemplate<>(producerFactory);
+		KafkaProducerMessageHandler<Integer, String> handler = new KafkaProducerMessageHandler<>(template);
+		handler.setBeanFactory(mock(BeanFactory.class));
+		PollableChannel successes = new QueueChannel();
+		handler.setSendSuccessChannel(successes);
+		handler.afterPropertiesSet();
+
+		Message<?> message = MessageBuilder.withPayload("foo")
+				.setHeader(KafkaHeaders.TOPIC, topic1)
+				.setHeader(KafkaHeaders.MESSAGE_KEY, 2)
+				.setHeader(KafkaHeaders.PARTITION_ID, 1)
+				.build();
+		handler.handleMessage(message);
+
+		ConsumerRecord<Integer, String> record = KafkaTestUtils.getSingleRecord(consumer, topic1);
+		assertThat(record).has(key(2));
+		assertThat(record).has(partition(1));
+		assertThat(record).has(value("foo"));
+		assertThat(successes.receive(10000)).isNotNull();
+
+		final RuntimeException fooException = new RuntimeException("foo");
+
+		handler = new KafkaProducerMessageHandler<>(new KafkaTemplate<Integer, String>(producerFactory) {
+
+			@Override
+			protected ListenableFuture<SendResult<Integer, String>> doSend(
+					ProducerRecord<Integer, String> producerRecord) {
+				SettableListenableFuture<SendResult<Integer, String>> future = new SettableListenableFuture<>();
+				future.setException(fooException);
+				return future;
+			}
+
+		});
+		PollableChannel failures = new QueueChannel();
+		handler.setSendFailureChannel(failures);
+		handler.setBeanFactory(mock(BeanFactory.class));
+		handler.afterPropertiesSet();
+		message = MessageBuilder.withPayload("bar")
+				.setHeader(KafkaHeaders.TOPIC, "foo")
+				.setHeader(KafkaHeaders.PARTITION_ID, 0)
+				.build();
+		handler.handleMessage(message);
+
+		Message<?> received = failures.receive(10000);
+		assertThat(received).isNotNull();
+		assertThat(received).isInstanceOf(ErrorMessage.class);
+		assertThat(((MessagingException) received.getPayload()).getFailedMessage()).isSameAs(message);
+		assertThat(((MessagingException) received.getPayload()).getCause()).isSameAs(fooException);
+		assertThat(((KafkaSendFailureException) received.getPayload()).getRecord()).isNotNull();
 	}
 
 }


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-integration-kafka/issues/172

Use `ErrorMessageStrategy` to build an error message in the event of a failure.

__Requires https://github.com/spring-projects/spring-kafka/pull/396__

__Cherry Pick to `master, 2.2.x, 2.1.x`__