### PR TITLE
GH-174: Remove redundant KafkaProdMH.Attributes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ ext {
 	jacksonVersion = '2.8.10'
 	log4jVersion = '2.8.2'
 	slf4jVersion = '1.7.25'
-	springIntegrationVersion = '4.3.11.RELEASE'
+	springIntegrationVersion = '4.3.12.RELEASE'
 	springKafkaVersion = '1.3.0.RC1'
 
 	idPrefix = 'kafka'

--- a/src/main/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandler.java
+++ b/src/main/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandler.java
@@ -23,7 +23,6 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 
-import org.springframework.core.AttributeAccessorSupport;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.Expression;
 import org.springframework.integration.MessageTimeoutException;
@@ -274,7 +273,7 @@ public class KafkaProducerMessageHandler<K, V> extends AbstractMessageProducingH
 					if (getSendFailureChannel() != null) {
 						KafkaProducerMessageHandler.this.messagingTemplate.send(getSendFailureChannel(),
 								KafkaProducerMessageHandler.this.errorMessageStrategy.buildErrorMessage(
-										new KafkaSendFailureException(message, producerRecord, ex), new Attributes()));
+										new KafkaSendFailureException(message, producerRecord, ex), null));
 					}
 				}
 
@@ -300,16 +299,6 @@ public class KafkaProducerMessageHandler<K, V> extends AbstractMessageProducingH
 	@Override
 	public String getComponentType() {
 		return "kafka:outbound-channel-adapter";
-	}
-
-	// TODO: Remove this when SI 4.3.12 is available.
-	@SuppressWarnings("serial")
-	private static final class Attributes extends AttributeAccessorSupport {
-
-		Attributes() {
-			super();
-		}
-
 	}
 
 }

--- a/src/main/java/org/springframework/integration/kafka/support/RawRecordHeaderErrorMessageStrategy.java
+++ b/src/main/java/org/springframework/integration/kafka/support/RawRecordHeaderErrorMessageStrategy.java
@@ -17,6 +17,7 @@
 package org.springframework.integration.kafka.support;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.springframework.core.AttributeAccessor;
@@ -31,6 +32,8 @@ import org.springframework.messaging.support.ErrorMessage;
  * a header to the {@link org.springframework.integration.message.EnhancedErrorMessage}.
  *
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 2.1.1
  *
  */
@@ -39,13 +42,20 @@ public class RawRecordHeaderErrorMessageStrategy implements ErrorMessageStrategy
 	@SuppressWarnings("deprecation")
 	@Override
 	public ErrorMessage buildErrorMessage(Throwable throwable, AttributeAccessor context) {
-		Object inputMessage = context.getAttribute(ErrorMessageUtils.INPUT_MESSAGE_CONTEXT_KEY);
-		Map<String, Object> headers = Collections.singletonMap(
-				KafkaMessageDrivenChannelAdapter.KAFKA_RAW_DATA,
-				context.getAttribute(KafkaMessageDrivenChannelAdapter.KAFKA_RAW_DATA));
+		Object inputMessage =
+				context == null
+						? null
+						: context.getAttribute(ErrorMessageUtils.INPUT_MESSAGE_CONTEXT_KEY);
+
+		Map<String, Object> headers =
+				context == null
+						? new HashMap<String, Object>()
+						: Collections.singletonMap(KafkaMessageDrivenChannelAdapter.KAFKA_RAW_DATA,
+								context.getAttribute(KafkaMessageDrivenChannelAdapter.KAFKA_RAW_DATA));
+
 		return inputMessage instanceof Message
 				? new org.springframework.integration.message.EnhancedErrorMessage(throwable, headers,
-						(Message<?>) inputMessage)
+				(Message<?>) inputMessage)
 				: new ErrorMessage(throwable, headers);
 	}
 


### PR DESCRIPTION
Resolves spring-projects/spring-integration-kafka#174

Since Spring Integration 4.3.12 all the `ErrorMessageStrategy`
implementation are able to deal with `null` for the `AttributeAccessor`