### PR TITLE
GH-185: Add deliveryAttempts header with retry

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ ext {
 	jacksonVersion = '2.9.1'
 	log4jVersion = '2.8.2'
 	slf4jVersion = '1.7.25'
-	springIntegrationVersion = '5.0.0.RELEASE'
+	springIntegrationVersion = '5.0.1.BUILD-SNAPSHOT'
 	springKafkaVersion = '2.1.0.RELEASE'
 
 	idPrefix = 'kafka'

--- a/src/main/java/org/springframework/integration/kafka/inbound/KafkaMessageDrivenChannelAdapter.java
+++ b/src/main/java/org/springframework/integration/kafka/inbound/KafkaMessageDrivenChannelAdapter.java
@@ -17,16 +17,19 @@
 package org.springframework.integration.kafka.inbound;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 
 import org.springframework.core.AttributeAccessor;
+import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.integration.context.OrderlyShutdownCapable;
 import org.springframework.integration.endpoint.MessageProducerSupport;
 import org.springframework.integration.kafka.support.RawRecordHeaderErrorMessageStrategy;
 import org.springframework.integration.support.ErrorMessageStrategy;
 import org.springframework.integration.support.ErrorMessageUtils;
+import org.springframework.integration.support.MessageBuilder;
 import org.springframework.kafka.listener.AbstractMessageListenerContainer;
 import org.springframework.kafka.listener.BatchMessageListener;
 import org.springframework.kafka.listener.MessageListener;
@@ -40,6 +43,7 @@ import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.kafka.support.converter.BatchMessageConverter;
 import org.springframework.kafka.support.converter.ConversionException;
+import org.springframework.kafka.support.converter.KafkaMessageHeaders;
 import org.springframework.kafka.support.converter.MessageConverter;
 import org.springframework.kafka.support.converter.RecordMessageConverter;
 import org.springframework.messaging.Message;
@@ -358,6 +362,9 @@ public class KafkaMessageDrivenChannelAdapter<K, V> extends MessageProducerSuppo
 			Message<?> message = null;
 			try {
 				message = toMessagingMessage(record, acknowledgment, consumer);
+				if (KafkaMessageDrivenChannelAdapter.this.retryTemplate != null) {
+					message = addDeliveryAttemptHeader(message);
+				}
 				setAttributesIfNecessary(record, message);
 			}
 			catch (RuntimeException e) {
@@ -378,6 +385,22 @@ public class KafkaMessageDrivenChannelAdapter<K, V> extends MessageProducerSuppo
 				KafkaMessageDrivenChannelAdapter.this.logger.debug("Converter returned a null message for: "
 						+ record);
 			}
+		}
+
+		private Message<?> addDeliveryAttemptHeader(Message<?> message) {
+			Message<?> messageToReturn = message;
+			AtomicInteger deliveryAttempt =
+					new AtomicInteger(((RetryContext) attributesHolder.get()).getRetryCount() + 1);
+			if (message.getHeaders() instanceof KafkaMessageHeaders) {
+				((KafkaMessageHeaders) message.getHeaders()).getRawHeaders()
+					.put(IntegrationMessageHeaderAccessor.DELIVERY_ATTEMPT, deliveryAttempt);
+			}
+			else {
+				messageToReturn = MessageBuilder.fromMessage(message)
+						.setHeader(IntegrationMessageHeaderAccessor.DELIVERY_ATTEMPT, deliveryAttempt)
+						.build();
+			}
+			return messageToReturn;
 		}
 
 		@Override

--- a/src/test/java/org/springframework/integration/kafka/inbound/MessageDrivenAdapterTests.java
+++ b/src/test/java/org/springframework/integration/kafka/inbound/MessageDrivenAdapterTests.java
@@ -39,6 +39,7 @@ import org.springframework.integration.handler.advice.ErrorMessageSendingRecover
 import org.springframework.integration.kafka.inbound.KafkaMessageDrivenChannelAdapter.ListenerMode;
 import org.springframework.integration.kafka.support.RawRecordHeaderErrorMessageStrategy;
 import org.springframework.integration.support.MessageBuilder;
+import org.springframework.integration.support.StaticMessageHeaderAccessor;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -195,7 +196,7 @@ public class MessageDrivenAdapterTests {
 		adapter.setOutputChannel(out);
 		RetryTemplate retryTemplate = new RetryTemplate();
 		SimpleRetryPolicy retryPolicy = new SimpleRetryPolicy();
-		retryPolicy.setMaxAttempts(1);
+		retryPolicy.setMaxAttempts(2);
 		retryTemplate.setRetryPolicy(retryPolicy);
 		QueueChannel errorChannel = new QueueChannel();
 		adapter.setRecoveryCallback(
@@ -222,6 +223,7 @@ public class MessageDrivenAdapterTests {
 		assertThat(headers.get(KafkaHeaders.RECEIVED_TOPIC)).isEqualTo(topic4);
 		assertThat(headers.get(KafkaHeaders.RECEIVED_PARTITION_ID)).isEqualTo(0);
 		assertThat(headers.get(KafkaHeaders.OFFSET)).isEqualTo(0L);
+		assertThat(StaticMessageHeaderAccessor.getDeliveryAttempt(received).get()).isEqualTo(2);
 
 		adapter.stop();
 	}


### PR DESCRIPTION
Resolves: https://github.com/spring-projects/spring-integration-kafka/issues/185

When a `RetryTemplate` is wired into the message-driven adapter, add
and increment an `AtomicInteger`-valued header.

See https://jira.spring.io/browse/INT-4369