### PR TITLE
GH-198: Support pause/resume on inbound adapter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ ext {
 	jacksonVersion = '2.9.1'
 	log4jVersion = '2.8.2'
 	slf4jVersion = '1.7.25'
-	springIntegrationVersion = '5.0.2.BUILD-SNAPSHOT'
+	springIntegrationVersion = '5.0.3.BUILD-SNAPSHOT'
 	springKafkaVersion = '2.1.3.BUILD-SNAPSHOT'
 
 	idPrefix = 'kafka'

--- a/src/main/java/org/springframework/integration/kafka/inbound/KafkaMessageDrivenChannelAdapter.java
+++ b/src/main/java/org/springframework/integration/kafka/inbound/KafkaMessageDrivenChannelAdapter.java
@@ -17,7 +17,6 @@
 package org.springframework.integration.kafka.inbound;
 
 import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.kafka.clients.consumer.Consumer;
@@ -80,12 +79,6 @@ public class KafkaMessageDrivenChannelAdapter<K, V> extends MessageProducerSuppo
 	private final IntegrationBatchMessageListener batchListener = new IntegrationBatchMessageListener();
 
 	private final ListenerMode mode;
-
-	private final AtomicBoolean pausePending = new AtomicBoolean();
-
-	private final AtomicBoolean resumePending = new AtomicBoolean();
-
-	private final AtomicBoolean paused = new AtomicBoolean();
 
 	private RecordFilterStrategy<K, V> recordFilterStrategy;
 

--- a/src/test/java/org/springframework/integration/kafka/inbound/MessageDrivenAdapterTests.java
+++ b/src/test/java/org/springframework/integration/kafka/inbound/MessageDrivenAdapterTests.java
@@ -17,17 +17,32 @@
 package org.springframework.integration.kafka.inbound;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.junit.ClassRule;
@@ -40,16 +55,20 @@ import org.springframework.integration.kafka.inbound.KafkaMessageDrivenChannelAd
 import org.springframework.integration.kafka.support.RawRecordHeaderErrorMessageStrategy;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.support.StaticMessageHeaderAccessor;
+import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.event.ListenerContainerIdleEvent;
+import org.springframework.kafka.listener.AbstractMessageListenerContainer.AckMode;
 import org.springframework.kafka.listener.KafkaMessageListenerContainer;
 import org.springframework.kafka.listener.config.ContainerProperties;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.kafka.support.DefaultKafkaHeaderMapper;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.kafka.support.KafkaNull;
+import org.springframework.kafka.support.TopicPartitionInitialOffset;
 import org.springframework.kafka.support.converter.BatchMessageConverter;
 import org.springframework.kafka.support.converter.BatchMessagingMessageConverter;
 import org.springframework.kafka.support.converter.ConversionException;
@@ -408,6 +427,68 @@ public class MessageDrivenAdapterTests {
 		assertThat(received.getPayload()).isInstanceOf(Foo.class);
 		assertThat(received.getPayload()).isEqualTo(new Foo("baz"));
 
+		adapter.stop();
+	}
+
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@Test
+	public void testPauseResume() throws Exception {
+		ConsumerFactory<Integer, String> cf = mock(ConsumerFactory.class);
+		Consumer<Integer, String> consumer = mock(Consumer.class);
+		given(cf.createConsumer(isNull(), eq("clientId"), isNull())).willReturn(consumer);
+		final Map<TopicPartition, List<ConsumerRecord<Integer, String>>> records = new HashMap<>();
+		records.put(new TopicPartition("foo", 0), Arrays.asList(
+				new ConsumerRecord<>("foo", 0, 0L, 1, "foo"),
+				new ConsumerRecord<>("foo", 0, 1L, 1, "bar")));
+		ConsumerRecords<Integer, String> consumerRecords = new ConsumerRecords<>(records);
+		ConsumerRecords<Integer, String> emptyRecords = new ConsumerRecords<>(Collections.emptyMap());
+		AtomicBoolean first = new AtomicBoolean(true);
+		given(consumer.poll(anyLong())).willAnswer(i -> {
+			Thread.sleep(50);
+			return first.getAndSet(false) ? consumerRecords : emptyRecords;
+		});
+		final CountDownLatch commitLatch = new CountDownLatch(2);
+		willAnswer(i -> {
+			commitLatch.countDown();
+			return null;
+		}).given(consumer).commitSync(any(Map.class));
+		given(consumer.assignment()).willReturn(records.keySet());
+		final CountDownLatch pauseLatch = new CountDownLatch(1);
+		willAnswer(i -> {
+			pauseLatch.countDown();
+			return null;
+		}).given(consumer).pause(records.keySet());
+		given(consumer.paused()).willReturn(records.keySet());
+		final CountDownLatch resumeLatch = new CountDownLatch(1);
+		willAnswer(i -> {
+			resumeLatch.countDown();
+			return null;
+		}).given(consumer).resume(records.keySet());
+		TopicPartitionInitialOffset[] topicPartition = new TopicPartitionInitialOffset[] {
+				new TopicPartitionInitialOffset("foo", 0) };
+		ContainerProperties containerProps = new ContainerProperties(topicPartition);
+		containerProps.setAckMode(AckMode.RECORD);
+		containerProps.setClientId("clientId");
+		containerProps.setIdleEventInterval(100L);
+		KafkaMessageListenerContainer<Integer, String> container =
+				new KafkaMessageListenerContainer<>(cf, containerProps);
+		KafkaMessageDrivenChannelAdapter adapter = new KafkaMessageDrivenChannelAdapter(container);
+		container.setApplicationEventPublisher(e -> {
+			if (e instanceof ListenerContainerIdleEvent) {
+				adapter.onApplicationEvent((ListenerContainerIdleEvent) e);
+			}
+		});
+		QueueChannel outputChannel = new QueueChannel();
+		adapter.setOutputChannel(outputChannel);
+		adapter.afterPropertiesSet();
+		adapter.start();
+		assertThat(commitLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		verify(consumer, times(2)).commitSync(any(Map.class));
+		assertThat(outputChannel.getQueueSize()).isEqualTo(2);
+		adapter.pause();
+		assertThat(pauseLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		adapter.resume();
+		assertThat(resumeLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		adapter.stop();
 	}
 

--- a/src/test/java/org/springframework/integration/kafka/inbound/MessageDrivenAdapterTests.java
+++ b/src/test/java/org/springframework/integration/kafka/inbound/MessageDrivenAdapterTests.java
@@ -60,7 +60,6 @@ import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
-import org.springframework.kafka.event.ListenerContainerIdleEvent;
 import org.springframework.kafka.listener.AbstractMessageListenerContainer.AckMode;
 import org.springframework.kafka.listener.KafkaMessageListenerContainer;
 import org.springframework.kafka.listener.config.ContainerProperties;
@@ -473,11 +472,6 @@ public class MessageDrivenAdapterTests {
 		KafkaMessageListenerContainer<Integer, String> container =
 				new KafkaMessageListenerContainer<>(cf, containerProps);
 		KafkaMessageDrivenChannelAdapter adapter = new KafkaMessageDrivenChannelAdapter(container);
-		container.setApplicationEventPublisher(e -> {
-			if (e instanceof ListenerContainerIdleEvent) {
-				adapter.onApplicationEvent((ListenerContainerIdleEvent) e);
-			}
-		});
 		QueueChannel outputChannel = new QueueChannel();
 		adapter.setOutputChannel(outputChannel);
 		adapter.afterPropertiesSet();


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-integration-kafka/issues/198

You can now pause/resume the consumer.

Any records previously fetched will be processed before the pause takes effect.
The listener container requires an `idleEventInterval`, a resume will take effect
on the next `ListenerContainerIdleEvent`.