### PR TITLE
GH-204: DSL Register container as a bean if needed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ target
 /bin/
 /classes/
 /out/
+.DS_Store

--- a/src/main/java/org/springframework/integration/kafka/dsl/Kafka.java
+++ b/src/main/java/org/springframework/integration/kafka/dsl/Kafka.java
@@ -104,7 +104,11 @@ public final class Kafka {
 	}
 
 	/**
-	 * Create an initial {@link KafkaMessageDrivenChannelAdapterSpec}.
+	 * Create an initial {@link KafkaMessageDrivenChannelAdapterSpec}. If the listener
+	 * container is not already a bean it will be registered in the application context.
+	 * If the adapter spec has an {@code id}, the bean name will be that id appended with
+	 * '.container. Otherwise, the bean name will be generated from the container class
+	 * name.
 	 * @param listenerContainer the {@link AbstractMessageListenerContainer}.
 	 * @param <K> the Kafka message key type.
 	 * @param <V> the Kafka message value type.
@@ -117,7 +121,11 @@ public final class Kafka {
 	}
 
 	/**
-	 * Create an initial {@link KafkaMessageDrivenChannelAdapterSpec}.
+	 * Create an initial {@link KafkaMessageDrivenChannelAdapterSpec}. If the listener
+	 * container is not already a bean it will be registered in the application context.
+	 * If the adapter spec has an {@code id}, the bean name will be that id appended with
+	 * '.container. Otherwise, the bean name will be generated from the container class
+	 * name.
 	 * @param listenerContainer the {@link AbstractMessageListenerContainer}.
 	 * @param listenerMode the {@link KafkaMessageDrivenChannelAdapter.ListenerMode}.
 	 * @param <K> the Kafka message key type.
@@ -316,7 +324,10 @@ public final class Kafka {
 
 	/**
 	 * Create an initial {@link KafkaInboundGatewaySpec} with the provided container and
-	 * template.
+	 * template. If the listener container is not already a bean it will be registered in
+	 * the application context. If the adapter spec has an {@code id}, the bean name will
+	 * be that id appended with '.container. Otherwise, the bean name will be generated
+	 * from the container class name.
 	 * @param container the container.
 	 * @param template the template.
 	 * @param <K> the Kafka message key type.

--- a/src/main/java/org/springframework/integration/kafka/dsl/KafkaInboundGatewaySpec.java
+++ b/src/main/java/org/springframework/integration/kafka/dsl/KafkaInboundGatewaySpec.java
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.kafka.dsl;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.function.Consumer;
 
@@ -44,12 +45,16 @@ import org.springframework.util.Assert;
  * @since 3.0.2
  */
 public class KafkaInboundGatewaySpec<K, V, R, S extends KafkaInboundGatewaySpec<K, V, R, S>>
-		extends MessagingGatewaySpec<S, KafkaInboundGateway<K, V, R>> {
+		extends MessagingGatewaySpec<S, KafkaInboundGateway<K, V, R>>
+		implements ComponentsRegistration {
+
+	private final AbstractMessageListenerContainer<K, V> container;
 
 	KafkaInboundGatewaySpec(AbstractMessageListenerContainer<K, V> messageListenerContainer,
 			KafkaTemplate<K, R> kafkaTemplate) {
 
 		super(new KafkaInboundGateway<>(messageListenerContainer, kafkaTemplate));
+		this.container = messageListenerContainer;
 	}
 
 	/**
@@ -84,6 +89,11 @@ public class KafkaInboundGatewaySpec<K, V, R, S extends KafkaInboundGatewaySpec<
 	public S recoveryCallback(RecoveryCallback<? extends Object> recoveryCallback) {
 		this.target.setRecoveryCallback(recoveryCallback);
 		return _this();
+	}
+
+	@Override
+	public Map<Object, String> getComponentsToRegister() {
+		return Collections.singletonMap(this.container, getId() == null ? null : getId() + ".container");
 	}
 
 	/**

--- a/src/main/java/org/springframework/integration/kafka/dsl/KafkaMessageDrivenChannelAdapterSpec.java
+++ b/src/main/java/org/springframework/integration/kafka/dsl/KafkaMessageDrivenChannelAdapterSpec.java
@@ -158,7 +158,7 @@ public class KafkaMessageDrivenChannelAdapterSpec<K, V, S extends KafkaMessageDr
 
 	@Override
 	public Map<Object, String> getComponentsToRegister() {
-		return Collections.singletonMap(this.container, getId());
+		return Collections.singletonMap(this.container, getId() == null ? null : getId() + ".container");
 	}
 
 	/**

--- a/src/main/java/org/springframework/integration/kafka/dsl/KafkaMessageDrivenChannelAdapterSpec.java
+++ b/src/main/java/org/springframework/integration/kafka/dsl/KafkaMessageDrivenChannelAdapterSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 the original author or authors.
+ * Copyright 2016-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,11 +46,15 @@ import org.springframework.util.Assert;
  * @since 3.0
  */
 public class KafkaMessageDrivenChannelAdapterSpec<K, V, S extends KafkaMessageDrivenChannelAdapterSpec<K, V, S>>
-		extends MessageProducerSpec<S, KafkaMessageDrivenChannelAdapter<K, V>> {
+		extends MessageProducerSpec<S, KafkaMessageDrivenChannelAdapter<K, V>>
+		implements ComponentsRegistration {
+
+	private final AbstractMessageListenerContainer<K, V> container;
 
 	KafkaMessageDrivenChannelAdapterSpec(AbstractMessageListenerContainer<K, V> messageListenerContainer,
 			KafkaMessageDrivenChannelAdapter.ListenerMode listenerMode) {
 		super(new KafkaMessageDrivenChannelAdapter<>(messageListenerContainer, listenerMode));
+		this.container = messageListenerContainer;
 	}
 
 	/**
@@ -150,6 +154,11 @@ public class KafkaMessageDrivenChannelAdapterSpec<K, V, S extends KafkaMessageDr
 	public S filterInRetry(boolean filterInRetry) {
 		this.target.setFilterInRetry(filterInRetry);
 		return _this();
+	}
+
+	@Override
+	public Map<Object, String> getComponentsToRegister() {
+		return Collections.singletonMap(this.container, getId());
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration-kafka/issues/204

When an external container is provided to the DSL, register it as a bean
if it is not already a bean.

@artembilan looks like this was an omission and perhaps should be back-ported (except the test).
