### PR TITLE
Fix TODOs in outbound channel adapter

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -29,6 +29,11 @@ In order to install this into your local maven cache:
 
 Documentation for this extension is contained in a chapter of the https://docs.spring.io/spring-kafka/reference/html/_spring_integration.html[Spring for Apache Kafka Reference Manual]
 
+== Migrating from 3.0 to 3.1
+
+Producer record metadata for sends performed on the outbound channel adapter are now sent only to the `successChannel`.
+With earlier versions, it was sent to the `outputChannel` if no `successChannel` was provided.
+
 == Contributing
 
 http://help.github.com/send-pull-requests[Pull requests] are welcome. Please see the https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc[contributor guidelines] for details.

--- a/src/main/java/org/springframework/integration/kafka/config/xml/KafkaOutboundChannelAdapterParser.java
+++ b/src/main/java/org/springframework/integration/kafka/config/xml/KafkaOutboundChannelAdapterParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,8 +85,7 @@ public class KafkaOutboundChannelAdapterParser extends AbstractOutboundChannelAd
 
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "error-message-strategy");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "send-failure-channel");
-		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "send-success-channel",
-				"outputChannel");
+		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "send-success-channel");
 
 		return builder.getBeanDefinition();
 	}

--- a/src/test/java/org/springframework/integration/kafka/config/xml/KafkaOutboundAdapterParserTests.java
+++ b/src/test/java/org/springframework/integration/kafka/config/xml/KafkaOutboundAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeoutException;
 
@@ -37,6 +36,7 @@ import org.springframework.expression.common.LiteralExpression;
 import org.springframework.integration.MessageTimeoutException;
 import org.springframework.integration.kafka.outbound.KafkaProducerMessageHandler;
 import org.springframework.integration.test.util.TestUtils;
+import org.springframework.kafka.core.KafkaProducerException;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.messaging.MessageHandlingException;
 import org.springframework.messaging.support.GenericMessage;
@@ -78,7 +78,7 @@ public class KafkaOutboundAdapterParserTests {
 				.isSameAs(this.appContext.getBean("ems"));
 		assertThat(TestUtils.getPropertyValue(messageHandler, "sendFailureChannel"))
 				.isSameAs(this.appContext.getBean("failures"));
-		assertThat(TestUtils.getPropertyValue(messageHandler, "outputChannel"))
+		assertThat(TestUtils.getPropertyValue(messageHandler, "sendSuccessChannel"))
 				.isSameAs(this.appContext.getBean("successes"));
 
 		messageHandler
@@ -125,7 +125,7 @@ public class KafkaOutboundAdapterParserTests {
 		}
 		catch (Exception e) {
 			assertThat(e).isInstanceOf(MessageHandlingException.class);
-			assertThat(e.getCause()).isExactlyInstanceOf(ExecutionException.class);
+			assertThat(e.getCause()).isExactlyInstanceOf(KafkaProducerException.class);
 			assertThat(e.getCause().getCause()).isInstanceOf(RuntimeException.class);
 			assertThat(e.getMessage()).contains("Async Producer Mock exception");
 		}

--- a/src/test/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandlerTests.java
+++ b/src/test/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandlerTests.java
@@ -256,7 +256,7 @@ public class KafkaProducerMessageHandlerTests {
 		KafkaProducerMessageHandler<Integer, String> handler = new KafkaProducerMessageHandler<>(template);
 		handler.setBeanFactory(mock(BeanFactory.class));
 		PollableChannel successes = new QueueChannel();
-		handler.setOutputChannel(successes);
+		handler.setSendSuccessChannel(successes);
 		handler.afterPropertiesSet();
 
 		Message<?> message = MessageBuilder.withPayload("foo")


### PR DESCRIPTION
- always use `successChannel` for metadata
- unwrap `ExecutionException`