### PR TITLE
Changes for compatibility with Spring Kafka 2.3

### DIFF
--- a/src/main/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandler.java
+++ b/src/main/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2018 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -460,6 +460,7 @@ public class KafkaProducerMessageHandler<K, V> extends AbstractReplyProducingMes
 	public void processSendResult(final Message<?> message, final ProducerRecord<K, V> producerRecord,
 			ListenableFuture<SendResult<K, V>> future, MessageChannel metadataChannel)
 			throws InterruptedException, ExecutionException {
+
 		if (getSendFailureChannel() != null || metadataChannel != null) {
 			future.addCallback(new ListenableFutureCallback<SendResult<K, V>>() {
 

--- a/src/test/java/org/springframework/integration/kafka/inbound/MessageDrivenAdapterTests.java
+++ b/src/test/java/org/springframework/integration/kafka/inbound/MessageDrivenAdapterTests.java
@@ -18,6 +18,7 @@ package org.springframework.integration.kafka.inbound;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
@@ -461,7 +462,7 @@ public class MessageDrivenAdapterTests {
 		willAnswer(i -> {
 			commitLatch.countDown();
 			return null;
-		}).given(consumer).commitSync(any(Map.class));
+		}).given(consumer).commitSync(anyMap(), any());
 		given(consumer.assignment()).willReturn(records.keySet());
 		final CountDownLatch pauseLatch = new CountDownLatch(1);
 		willAnswer(i -> {
@@ -488,7 +489,7 @@ public class MessageDrivenAdapterTests {
 		adapter.afterPropertiesSet();
 		adapter.start();
 		assertThat(commitLatch.await(10, TimeUnit.SECONDS)).isTrue();
-		verify(consumer, times(2)).commitSync(any(Map.class));
+		verify(consumer, times(2)).commitSync(anyMap(), any());
 		assertThat(outputChannel.getQueueSize()).isEqualTo(2);
 		adapter.pause();
 		assertThat(pauseLatch.await(10, TimeUnit.SECONDS)).isTrue();

--- a/src/test/java/org/springframework/integration/kafka/inbound/MessageSourceTests.java
+++ b/src/test/java/org/springframework/integration/kafka/inbound/MessageSourceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -268,6 +268,7 @@ public class MessageSourceTests {
 				.getConfigurationProperties();
 		given(consumerFactory.createConsumer(isNull(), anyString(), isNull())).willReturn(consumer);
 		KafkaMessageSource source = new KafkaMessageSource(consumerFactory, "foo");
+		source.setCommitTimeout(Duration.ofSeconds(30));
 
 		Message<?> received = source.receive();
 		assertThat(received.getHeaders().get(KafkaHeaders.OFFSET)).isEqualTo(0L);
@@ -292,11 +293,13 @@ public class MessageSourceTests {
 		inOrder.verify(consumer).poll(any(Duration.class));
 		inOrder.verify(consumer).seek(topicPartition, 0L); // rollback
 		inOrder.verify(consumer).poll(any(Duration.class));
-		inOrder.verify(consumer).commitSync(Collections.singletonMap(topicPartition, new OffsetAndMetadata(1L)));
+		inOrder.verify(consumer).commitSync(Collections.singletonMap(topicPartition, new OffsetAndMetadata(1L)),
+				Duration.ofSeconds(30));
 		inOrder.verify(consumer).poll(any(Duration.class));
 		inOrder.verify(consumer).seek(topicPartition, 1L); // rollback
 		inOrder.verify(consumer).poll(any(Duration.class));
-		inOrder.verify(consumer).commitSync(Collections.singletonMap(topicPartition, new OffsetAndMetadata(2L)));
+		inOrder.verify(consumer).commitSync(Collections.singletonMap(topicPartition, new OffsetAndMetadata(2L)),
+				Duration.ofSeconds(30));
 		inOrder.verify(consumer).poll(any(Duration.class));
 		inOrder.verify(consumer).close();
 		inOrder.verifyNoMoreInteractions();


### PR DESCRIPTION
Also remove test for bad partition in DSL tests - the send now gives an error
about the topic not being present in metadata instead of "not in range".

Use sync for publishing in DSL tests, to fail fast.