### PR TITLE
URL Cleanup

### DIFF
--- a/src/checkstyle/checkstyle-suppressions.xml
+++ b/src/checkstyle/checkstyle-suppressions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE suppressions PUBLIC
     "-//Puppy Crawl//DTD Suppressions 1.1//EN"
-    "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+    "https://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
 <suppressions>
 	<suppress files="package-info\.java" checks=".*" />
 	<suppress files="[\\/]test[\\/]" checks="RequireThis" />

--- a/src/checkstyle/checkstyle.xml
+++ b/src/checkstyle/checkstyle.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.2//EN" "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.2//EN" "https://www.puppycrawl.com/dtds/configuration_1_2.dtd">
 <module name="Checker">
 
 	<module name="SuppressionFilter">

--- a/src/test/java/org/springframework/integration/kafka/config/xml/KafkaMessageDrivenChannelAdapterParserTests-context.xml
+++ b/src/test/java/org/springframework/integration/kafka/config/xml/KafkaMessageDrivenChannelAdapterParserTests-context.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:int-kafka="http://www.springframework.org/schema/integration/kafka"
-	xmlns:context="http://www.springframework.org/schema/context"
-	xmlns:task="http://www.springframework.org/schema/task"
-	xmlns:util="http://www.springframework.org/schema/util"
-	xsi:schemaLocation="http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-		http://www.springframework.org/schema/integration/kafka http://www.springframework.org/schema/integration/kafka/spring-integration-kafka.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+<beans xmlns="https://www.springframework.org/schema/beans"
+	xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	xmlns:int-kafka="https://www.springframework.org/schema/integration/kafka"
+	xmlns:context="https://www.springframework.org/schema/context"
+	xmlns:task="https://www.springframework.org/schema/task"
+	xmlns:util="https://www.springframework.org/schema/util"
+	xsi:schemaLocation="https://www.springframework.org/schema/task https://www.springframework.org/schema/task/spring-task.xsd
+		https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		https://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+		https://www.springframework.org/schema/integration/kafka https://www.springframework.org/schema/integration/kafka/spring-integration-kafka.xsd
+		https://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 
 	<context:property-placeholder/>
 

--- a/src/test/java/org/springframework/integration/kafka/config/xml/KafkaOutboundAdapterParserTests-context.xml
+++ b/src/test/java/org/springframework/integration/kafka/config/xml/KafkaOutboundAdapterParserTests-context.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans"
-	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:int="http://www.springframework.org/schema/integration"
-	   xmlns:int-kafka="http://www.springframework.org/schema/integration/kafka"
-	   xsi:schemaLocation="http://www.springframework.org/schema/integration/kafka http://www.springframework.org/schema/integration/kafka/spring-integration-kafka.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+<beans xmlns="https://www.springframework.org/schema/beans"
+	   xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:int="https://www.springframework.org/schema/integration"
+	   xmlns:int-kafka="https://www.springframework.org/schema/integration/kafka"
+	   xsi:schemaLocation="https://www.springframework.org/schema/integration/kafka https://www.springframework.org/schema/integration/kafka/spring-integration-kafka.xsd
+		https://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<int:channel id="inputToKafka" />
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://www.puppycrawl.com/dtds/configuration_1_2.dtd (404) with 1 occurrences migrated to:  
  https://www.puppycrawl.com/dtds/configuration_1_2.dtd ([https](https://www.puppycrawl.com/dtds/configuration_1_2.dtd) result 404).
* [ ] http://www.puppycrawl.com/dtds/suppressions_1_1.dtd (404) with 1 occurrences migrated to:  
  https://www.puppycrawl.com/dtds/suppressions_1_1.dtd ([https](https://www.puppycrawl.com/dtds/suppressions_1_1.dtd) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.springframework.org/schema/beans/spring-beans.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans.xsd ([https](https://www.springframework.org/schema/beans/spring-beans.xsd) result 200).
* [ ] http://www.springframework.org/schema/context/spring-context.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context.xsd ([https](https://www.springframework.org/schema/context/spring-context.xsd) result 200).
* [ ] http://www.springframework.org/schema/integration/kafka/spring-integration-kafka.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/integration/kafka/spring-integration-kafka.xsd ([https](https://www.springframework.org/schema/integration/kafka/spring-integration-kafka.xsd) result 200).
* [ ] http://www.springframework.org/schema/integration/spring-integration.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/integration/spring-integration.xsd ([https](https://www.springframework.org/schema/integration/spring-integration.xsd) result 200).
* [ ] http://www.springframework.org/schema/task/spring-task.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/task/spring-task.xsd ([https](https://www.springframework.org/schema/task/spring-task.xsd) result 200).
* [ ] http://www.springframework.org/schema/util/spring-util.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/util/spring-util.xsd ([https](https://www.springframework.org/schema/util/spring-util.xsd) result 200).
* [ ] http://www.w3.org/2001/XMLSchema-instance with 2 occurrences migrated to:  
  https://www.w3.org/2001/XMLSchema-instance ([https](https://www.w3.org/2001/XMLSchema-instance) result 200).
* [ ] http://www.springframework.org/schema/beans with 4 occurrences migrated to:  
  https://www.springframework.org/schema/beans ([https](https://www.springframework.org/schema/beans) result 301).
* [ ] http://www.springframework.org/schema/context with 2 occurrences migrated to:  
  https://www.springframework.org/schema/context ([https](https://www.springframework.org/schema/context) result 301).
* [ ] http://www.springframework.org/schema/integration with 2 occurrences migrated to:  
  https://www.springframework.org/schema/integration ([https](https://www.springframework.org/schema/integration) result 301).
* [ ] http://www.springframework.org/schema/integration/kafka with 4 occurrences migrated to:  
  https://www.springframework.org/schema/integration/kafka ([https](https://www.springframework.org/schema/integration/kafka) result 301).
* [ ] http://www.springframework.org/schema/task with 2 occurrences migrated to:  
  https://www.springframework.org/schema/task ([https](https://www.springframework.org/schema/task) result 301).
* [ ] http://www.springframework.org/schema/util with 2 occurrences migrated to:  
  https://www.springframework.org/schema/util ([https](https://www.springframework.org/schema/util) result 301).