### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Spring Integration Kafka Adapter
 
 The *Spring Integration Kafka Adapter* provides client components for Apache Kafka. Apache Kafka is a distributed publish-subscribe messaging system
 that is designed for high throughput (terabytes of data) and low latency (miliseconds). For more information on Kafka
-and its design goals, see [Kafka main page](http://kafka.apache.org/).
+and its design goals, see [Kafka main page](https://kafka.apache.org/).
 
 In particular, Spring Integration Kafka provides:
 
@@ -194,7 +194,7 @@ also available in a package called avro under serializer.
 
 #### Tuning Producer Properties
 
-Kafka Producer API provides several [Producer Configs] (http://kafka.apache.org/documentation.html#producerconfigs) to fine-tune producers.
+Kafka Producer API provides several [Producer Configs] (https://kafka.apache.org/documentation.html#producerconfigs) to fine-tune producers.
 To specify those properties, `producer-context` element supports optional `producer-properties` attribute that can reference the Spring properties bean.
 These properties will be applied to all Producer Configurations within the producer context. For example:
 
@@ -447,7 +447,7 @@ If your use case does not require ordering of messages during consumption, then 
 payload to a standard SI transformer and just get a full dump of the actual payload sent by Kafka.
 
 #### Tuning Consumer Properties
-Kafka Consumer API provides several [Consumer Configs] (http://kafka.apache.org/documentation.html#consumerconfigs) to fine tune consumers.
+Kafka Consumer API provides several [Consumer Configs] (https://kafka.apache.org/documentation.html#consumerconfigs) to fine tune consumers.
 To specify those properties, `consumer-context` element supports optional `consumer-properties` attribute that can reference the spring properties bean.
 This properties will be applied to all Consumer Configurations within the consumer context. For Eg:
 

--- a/src/api/overview.html
+++ b/src/api/overview.html
@@ -5,7 +5,7 @@ This document is the API specification for Spring Integration Kafka Extension
 <div id="overviewBody">
     <p>
         For further API reference and developer documentation, see the
-        <a href="http://static.springsource.org/spring-integration/reference" target="_top">Spring
+        <a href="https://docs.spring.io/spring-integration/reference" target="_top">Spring
             Integration reference documentation</a>.
         That documentation contains more detailed, developer-targeted
         descriptions, with conceptual overviews, definitions of terms,
@@ -14,8 +14,8 @@ This document is the API specification for Spring Integration Kafka Extension
 
     <p>
         If you are interested in commercial training, consultancy, and
-        support for Spring Integration, please visit <a href="http://www.springsource.com" target="_top">
-        http://www.springsource.com</a>
+        support for Spring Integration, please visit <a href="https://www.springsource.com" target="_top">
+        https://www.springsource.com</a>
     </p>
 </div>
 </body>

--- a/src/dist/notice.txt
+++ b/src/dist/notice.txt
@@ -4,13 +4,13 @@
    ========================================================================
 
    This product includes software developed by
-   the Apache Software Foundation (http://www.apache.org).
+   the Apache Software Foundation (https://www.apache.org).
 
    The end-user documentation included with a redistribution, if any,
    must include the following acknowledgement:
 
      "This product includes software developed by the Spring Framework
-      Project (http://www.springframework.org)."
+      Project (https://www.springframework.org)."
 
    Alternatively, this acknowledgement may appear in the software itself,
    if and wherever such third-party acknowledgements normally appear.

--- a/src/main/resources/org/springframework/integration/kafka/config/spring-integration-kafka-1.3.xsd
+++ b/src/main/resources/org/springframework/integration/kafka/config/spring-integration-kafka-1.3.xsd
@@ -9,7 +9,7 @@
 	<xsd:import namespace="http://www.springframework.org/schema/beans"/>
 	<xsd:import namespace="http://www.springframework.org/schema/tool"/>
 	<xsd:import namespace="http://www.springframework.org/schema/integration"
-				schemaLocation="http://www.springframework.org/schema/integration/spring-integration.xsd"/>
+				schemaLocation="https://www.springframework.org/schema/integration/spring-integration.xsd"/>
 
 	<xsd:annotation>
 		<xsd:documentation><![CDATA[


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://kafka.apache.org/ with 1 occurrences migrated to:  
  https://kafka.apache.org/ ([https](https://kafka.apache.org/) result 200).
* [ ] http://kafka.apache.org/documentation.html with 2 occurrences migrated to:  
  https://kafka.apache.org/documentation.html ([https](https://kafka.apache.org/documentation.html) result 200).
* [ ] http://www.apache.org with 1 occurrences migrated to:  
  https://www.apache.org ([https](https://www.apache.org) result 200).
* [ ] http://www.springframework.org/schema/integration/spring-integration.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/integration/spring-integration.xsd ([https](https://www.springframework.org/schema/integration/spring-integration.xsd) result 200).
* [ ] http://static.springsource.org/spring-integration/reference (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-integration/reference ([https](https://static.springsource.org/spring-integration/reference) result 301).
* [ ] http://www.springframework.org with 1 occurrences migrated to:  
  https://www.springframework.org ([https](https://www.springframework.org) result 301).
* [ ] http://www.springsource.com with 2 occurrences migrated to:  
  https://www.springsource.com ([https](https://www.springsource.com) result 301).

# Ignored
These URLs were intentionally ignored.

* http://www.springframework.org/schema/beans with 1 occurrences
* http://www.springframework.org/schema/integration with 2 occurrences
* http://www.springframework.org/schema/integration/kafka with 2 occurrences
* http://www.springframework.org/schema/tool with 2 occurrences
* http://www.w3.org/2001/XMLSchema with 1 occurrences