### PR TITLE
URL Cleanup

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -6,14 +6,14 @@ The *Spring Integration Kafka* extension project provides inbound and outbound c
 Apache Kafka is a distributed publish-subscribe messaging system
 that is designed for high throughput (terabytes of data) and low latency (milliseconds). For more information on Kafka
 and its design goals, see the
-http://kafka.apache.org/[Kafka main page].
+https://kafka.apache.org/[Kafka main page].
 
 This 2.0 version is a complete rewrite based on the new
 https://github.com/spring-projects/spring-kafka[spring-kafka] project which uses the pure java `Producer` and
 `Consumer` clients provided by Kafka 0.9.x.x.
 
 That project is currently at Release Candidate 1 and its
-http://docs.spring.io/spring-kafka/docs/1.0.0.RC1/reference/htmlsingle/[documentation is here].
+https://docs.spring.io/spring-kafka/docs/1.0.0.RC1/reference/htmlsingle/[documentation is here].
 
 == Quick Start
 
@@ -159,4 +159,4 @@ Since messages can't have `null` payloads, when such a value is received, it is 
 
 ## Contributing
 
-http://help.github.com/send-pull-requests[Pull requests] are welcome. Please see the https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc[contributor guidelines] for details.
+https://help.github.com/send-pull-requests[Pull requests] are welcome. Please see the https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc[contributor guidelines] for details.

--- a/src/api/overview.html
+++ b/src/api/overview.html
@@ -5,7 +5,7 @@ This document is the API specification for Spring Integration Kafka Extension
 <div id="overviewBody">
     <p>
         For further API reference and developer documentation, see the
-        <a href="http://static.springsource.org/spring-integration/reference" target="_top">Spring
+        <a href="https://docs.spring.io/spring-integration/reference" target="_top">Spring
             Integration reference documentation</a>.
         That documentation contains more detailed, developer-targeted
         descriptions, with conceptual overviews, definitions of terms,
@@ -14,8 +14,8 @@ This document is the API specification for Spring Integration Kafka Extension
 
     <p>
         If you are interested in commercial training, consultancy, and
-        support for Spring Integration, please visit <a href="http://www.springsource.com" target="_top">
-        http://www.springsource.com</a>
+        support for Spring Integration, please visit <a href="https://www.springsource.com" target="_top">
+        https://www.springsource.com</a>
     </p>
 </div>
 </body>

--- a/src/dist/notice.txt
+++ b/src/dist/notice.txt
@@ -4,13 +4,13 @@
    ========================================================================
 
    This product includes software developed by
-   the Apache Software Foundation (http://www.apache.org).
+   the Apache Software Foundation (https://www.apache.org).
 
    The end-user documentation included with a redistribution, if any,
    must include the following acknowledgement:
 
      "This product includes software developed by the Spring Framework
-      Project (http://www.springframework.org)."
+      Project (https://www.springframework.org)."
 
    Alternatively, this acknowledgement may appear in the software itself,
    if and wherever such third-party acknowledgements normally appear.

--- a/src/main/resources/org/springframework/integration/kafka/config/spring-integration-kafka-2.0.xsd
+++ b/src/main/resources/org/springframework/integration/kafka/config/spring-integration-kafka-2.0.xsd
@@ -9,7 +9,7 @@
 	<xsd:import namespace="http://www.springframework.org/schema/beans"/>
 	<xsd:import namespace="http://www.springframework.org/schema/tool"/>
 	<xsd:import namespace="http://www.springframework.org/schema/integration"
-				schemaLocation="http://www.springframework.org/schema/integration/spring-integration.xsd"/>
+				schemaLocation="https://www.springframework.org/schema/integration/spring-integration.xsd"/>
 
 	<xsd:annotation>
 		<xsd:documentation><![CDATA[


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://help.github.com/send-pull-requests (404) with 1 occurrences migrated to:  
  https://help.github.com/send-pull-requests ([https](https://help.github.com/send-pull-requests) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://docs.spring.io/spring-kafka/docs/1.0.0.RC1/reference/htmlsingle/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-kafka/docs/1.0.0.RC1/reference/htmlsingle/ ([https](https://docs.spring.io/spring-kafka/docs/1.0.0.RC1/reference/htmlsingle/) result 200).
* [ ] http://kafka.apache.org/ with 1 occurrences migrated to:  
  https://kafka.apache.org/ ([https](https://kafka.apache.org/) result 200).
* [ ] http://www.apache.org with 1 occurrences migrated to:  
  https://www.apache.org ([https](https://www.apache.org) result 200).
* [ ] http://www.springframework.org/schema/integration/spring-integration.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/integration/spring-integration.xsd ([https](https://www.springframework.org/schema/integration/spring-integration.xsd) result 200).
* [ ] http://static.springsource.org/spring-integration/reference (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-integration/reference ([https](https://static.springsource.org/spring-integration/reference) result 301).
* [ ] http://www.springframework.org with 1 occurrences migrated to:  
  https://www.springframework.org ([https](https://www.springframework.org) result 301).
* [ ] http://www.springsource.com with 2 occurrences migrated to:  
  https://www.springsource.com ([https](https://www.springsource.com) result 301).

# Ignored
These URLs were intentionally ignored.

* http://www.springframework.org/schema/beans with 1 occurrences
* http://www.springframework.org/schema/integration with 2 occurrences
* http://www.springframework.org/schema/integration/kafka with 2 occurrences
* http://www.springframework.org/schema/tool with 2 occurrences
* http://www.w3.org/2001/XMLSchema with 1 occurrences