### PR TITLE
GH-260: Fix outbound tx synchronization

### DIFF
--- a/src/main/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandler.java
+++ b/src/main/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandler.java
@@ -395,7 +395,8 @@ public class KafkaProducerMessageHandler<K, V> extends AbstractReplyProducingMes
 			sendFuture = gatewayFuture.getSendFuture();
 		}
 		else {
-			if (this.transactional && !TransactionSynchronizationManager.isActualTransactionActive()) {
+			if (this.transactional
+					&& TransactionSynchronizationManager.getResource(this.kafkaTemplate.getProducerFactory()) == null) {
 				sendFuture = this.kafkaTemplate.executeInTransaction(t -> {
 					return t.send(producerRecord);
 				});


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-integration-kafka/issues/260

The outbound endpoint used
`TransactionSynchronizationManager.isActualTransactionActive()`
to detect a global transaction instead of
`TransactionSynchronizationManager.getResource(this.kafkaTemplate.getProducerFactory()) == null`.

The KTM uses `SYNCHRONIZATION_NEVER` by default so the first will
return false unless the synchronization is explicitly set. This
causes a new transaction to be started.

Use the presence of the resource holder instead.

**cherry-pick to 3.1.x**