### PR TITLE
GH-259: Add pause/resume to KafkaMessageSource

### DIFF
--- a/src/main/java/org/springframework/integration/kafka/inbound/KafkaMessageSource.java
+++ b/src/main/java/org/springframework/integration/kafka/inbound/KafkaMessageSource.java
@@ -42,7 +42,6 @@ import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.WakeupException;
 
-import org.springframework.context.Lifecycle;
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.integration.acks.AcknowledgmentCallback;
 import org.springframework.integration.acks.AcknowledgmentCallbackFactory;
@@ -86,7 +85,7 @@ import org.springframework.util.Assert;
  * @since 3.0.1
  *
  */
-public class KafkaMessageSource<K, V> extends AbstractMessageSource<Object> implements Lifecycle, Pausable {
+public class KafkaMessageSource<K, V> extends AbstractMessageSource<Object> implements Pausable {
 
 	private static final long DEFAULT_POLL_TIMEOUT = 50L;
 

--- a/src/main/java/org/springframework/integration/kafka/inbound/KafkaMessageSource.java
+++ b/src/main/java/org/springframework/integration/kafka/inbound/KafkaMessageSource.java
@@ -70,7 +70,7 @@ import org.springframework.util.Assert;
  * processed successfully. Applications should therefore implement
  * idempotency.
  * <p>
- * Starting with version 2.2.5, this source implements {@link Pausable} which
+ * Starting with version 3.1.2, this source implements {@link Pausable} which
  * allows you to pause and resume the {@link Consumer}. While the consumer is
  * paused, you must continue to call {@link #receive()} within
  * {@code max.poll.interval.ms}, to prevent a rebalance.

--- a/src/test/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandlerTests.java
+++ b/src/test/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandlerTests.java
@@ -44,6 +44,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -128,8 +129,9 @@ public class KafkaProducerMessageHandlerTests {
 
 	@BeforeClass
 	public static void setUp() {
-		ConsumerFactory<Integer, String> cf = new DefaultKafkaConsumerFactory<>(
-				KafkaTestUtils.consumerProps("testOut", "true", embeddedKafka));
+		Map<String, Object> consumerProps = KafkaTestUtils.consumerProps("testOut", "true", embeddedKafka);
+		consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+		ConsumerFactory<Integer, String> cf = new DefaultKafkaConsumerFactory<>(consumerProps);
 		consumer = cf.createConsumer();
 		embeddedKafka.consumeFromAllEmbeddedTopics(consumer);
 	}


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-integration-kafka/issues/259

Enable pause/resume on the polled consumer.

**cherry-pick to 3.1.x**