### PR TITLE
GH-265: Ensure assignTimeout is used when no partitions are assigned

### DIFF
--- a/src/main/java/org/springframework/integration/kafka/inbound/KafkaMessageSource.java
+++ b/src/main/java/org/springframework/integration/kafka/inbound/KafkaMessageSource.java
@@ -81,6 +81,7 @@ import org.springframework.util.Assert;
  * @author Gary Russell
  * @author Mark Norkin
  * @author Artem Bilan
+ * @author Anshul Mehra
  *
  * @since 3.0.1
  *
@@ -123,8 +124,6 @@ public class KafkaMessageSource<K, V> extends AbstractMessageSource<Object> impl
 	private Duration commitTimeout;
 
 	private boolean running;
-
-	private boolean assigned;
 
 	private Duration assignTimeout = this.minTimeoutProvider.get();
 
@@ -346,7 +345,7 @@ public class KafkaMessageSource<K, V> extends AbstractMessageSource<Object> impl
 		ConsumerRecord<K, V> record;
 		TopicPartition topicPartition;
 		synchronized (this.consumerMonitor) {
-			ConsumerRecords<K, V> records = this.consumer.poll(this.assigned ? this.pollTimeout : this.assignTimeout);
+			ConsumerRecords<K, V> records = this.consumer.poll(this.assignedPartitions.isEmpty() ? this.assignTimeout : this.pollTimeout);
 			if (records == null || records.count() == 0) {
 				return null;
 			}
@@ -402,7 +401,6 @@ public class KafkaMessageSource<K, V> extends AbstractMessageSource<Object> impl
 				@Override
 				public void onPartitionsAssigned(Collection<TopicPartition> partitions) {
 					KafkaMessageSource.this.assignedPartitions = new ArrayList<>(partitions);
-					KafkaMessageSource.this.assigned = true;
 					if (KafkaMessageSource.this.logger.isInfoEnabled()) {
 						KafkaMessageSource.this.logger.info("Partitions assigned: " + partitions);
 					}
@@ -429,7 +427,7 @@ public class KafkaMessageSource<K, V> extends AbstractMessageSource<Object> impl
 			if (this.consumer != null) {
 				this.consumer.close();
 				this.consumer = null;
-				this.assigned = false;
+				this.assignedPartitions.clear();
 			}
 		}
 	}


### PR DESCRIPTION
* Refactored to rely on assignedPartitions for determining whether to
use pollTimeout or assignTimeout
* Removed redundant assigned flag

fixes #265