### PR TITLE
SIGH-2958: Add source record to common SI Header

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ ext {
 	junitJupiterVersion = '5.4.2'
 	junitPlatformVersion = '1.4.2'
 	log4jVersion = '2.11.2'
-	springIntegrationVersion = '5.2.0.M2'
+	springIntegrationVersion = '5.2.0.BUILD-SNAPSHOT'
 	springKafkaVersion = '2.3.0.M2'
 
 	idPrefix = 'kafka'

--- a/src/main/java/org/springframework/integration/kafka/inbound/KafkaMessageSource.java
+++ b/src/main/java/org/springframework/integration/kafka/inbound/KafkaMessageSource.java
@@ -310,9 +310,10 @@ public class KafkaMessageSource<K, V> extends AbstractMessageSource<Object> impl
 	}
 
 	/**
-	 * Set to true to include the raw {@link ConsumerRecord} as a header
-	 * with key {@link KafkaHeaders#RAW_DATA},
-	 * enabling callers to have access to the record to process errors.
+	 * Set to true to include the raw {@link ConsumerRecord} as headers with keys
+	 * {@link KafkaHeaders#RAW_DATA} and
+	 * {@link IntegrationMessageHeaderAccessor#SOURCE_DATA}. enabling callers to have
+	 * access to the record to process errors.
 	 * @param rawMessageHeader true to include the header.
 	 */
 	public void setRawMessageHeader(boolean rawMessageHeader) {
@@ -458,6 +459,7 @@ public class KafkaMessageSource<K, V> extends AbstractMessageSource<Object> impl
 			rawHeaders.put(REMAINING_RECORDS, this.remainingCount.get());
 			if (this.rawMessageHeader) {
 				rawHeaders.put(KafkaHeaders.RAW_DATA, record);
+				rawHeaders.put(IntegrationMessageHeaderAccessor.SOURCE_DATA, record);
 			}
 			return message;
 		}
@@ -467,6 +469,7 @@ public class KafkaMessageSource<K, V> extends AbstractMessageSource<Object> impl
 					.setHeader(REMAINING_RECORDS, this.remainingCount.get());
 			if (this.rawMessageHeader) {
 				builder.setHeader(KafkaHeaders.RAW_DATA, record);
+				builder.setHeader(IntegrationMessageHeaderAccessor.SOURCE_DATA, record);
 			}
 			return builder;
 		}

--- a/src/main/java/org/springframework/integration/kafka/support/RawRecordHeaderErrorMessageStrategy.java
+++ b/src/main/java/org/springframework/integration/kafka/support/RawRecordHeaderErrorMessageStrategy.java
@@ -16,10 +16,11 @@
 
 package org.springframework.integration.kafka.support;
 
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.springframework.core.AttributeAccessor;
+import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.integration.support.ErrorMessageStrategy;
 import org.springframework.integration.support.ErrorMessageUtils;
 import org.springframework.kafka.support.KafkaHeaders;
@@ -41,9 +42,13 @@ public class RawRecordHeaderErrorMessageStrategy implements ErrorMessageStrategy
 
 	@Override
 	public ErrorMessage buildErrorMessage(Throwable throwable, @Nullable AttributeAccessor context) {
-		Object inputMessage = context.getAttribute(ErrorMessageUtils.INPUT_MESSAGE_CONTEXT_KEY);
-		Map<String, Object> headers =
-				Collections.singletonMap(KafkaHeaders.RAW_DATA, context.getAttribute(KafkaHeaders.RAW_DATA));
+		Object inputMessage = null;
+		Map<String, Object> headers = new HashMap<>();
+		if (context != null) {
+			inputMessage = context.getAttribute(ErrorMessageUtils.INPUT_MESSAGE_CONTEXT_KEY);
+			headers.put(KafkaHeaders.RAW_DATA, context.getAttribute(KafkaHeaders.RAW_DATA));
+			headers.put(IntegrationMessageHeaderAccessor.SOURCE_DATA, context.getAttribute(KafkaHeaders.RAW_DATA));
+		}
 		if (inputMessage instanceof Message) {
 			return new ErrorMessage(throwable, headers, (Message<?>) inputMessage);
 		}

--- a/src/test/java/org/springframework/integration/kafka/inbound/MessageSourceTests.java
+++ b/src/test/java/org/springframework/integration/kafka/inbound/MessageSourceTests.java
@@ -56,6 +56,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 
 import org.springframework.beans.DirectFieldAccessor;
+import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.integration.StaticMessageHeaderAccessor;
 import org.springframework.integration.acks.AcknowledgmentCallback;
 import org.springframework.integration.test.util.TestUtils;
@@ -116,6 +117,8 @@ public class MessageSourceTests {
 		Message<?> received = source.receive();
 		assertThat(received).isNotNull();
 		assertThat(received.getHeaders().get(KafkaHeaders.RAW_DATA)).isInstanceOf(ConsumerRecord.class);
+		assertThat(received.getHeaders().get(IntegrationMessageHeaderAccessor.SOURCE_DATA))
+			.isSameAs(received.getHeaders().get(KafkaHeaders.RAW_DATA));
 		StaticMessageHeaderAccessor.getAcknowledgmentCallback(received)
 				.acknowledge(AcknowledgmentCallback.Status.ACCEPT);
 		received = source.receive();


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-integration/issues/2958

Enables applications to be agnostic regarding the source of
a message. e.g Kafka Vs. AMQP.