### PR TITLE
GH-280: Add topicPattern support to KafkaMessageSource

### DIFF
--- a/src/main/java/org/springframework/integration/kafka/config/xml/KafkaInboundChannelAdapterParser.java
+++ b/src/main/java/org/springframework/integration/kafka/config/xml/KafkaInboundChannelAdapterParser.java
@@ -30,6 +30,7 @@ import org.springframework.util.StringUtils;
  * Parser for the inbound channel adapter.
  *
  * @author Gary Russell
+ * @author Anshul Mehra
  * @since 3.2
  *
  */
@@ -52,13 +53,21 @@ public class KafkaInboundChannelAdapterParser extends AbstractPollingInboundChan
 		if (StringUtils.hasText(attribute)) {
 			builder.addConstructorArgValue(attribute);
 		}
-		builder.addConstructorArgValue(element.getAttribute("topics"));
+
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "client-id");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "group-id");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "message-converter");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "payload-type");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "raw-header", "rawMessageHeader");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "rebalance-listener");
+
+		attribute = element.getAttribute("topics");
+		if (StringUtils.hasText(attribute)) {
+			builder.addPropertyValue("topics", element.getAttribute("topics"));
+		}
+		else {
+			builder.addPropertyValue("topicPattern", element.getAttribute("topicPattern"));
+		}
 		return builder.getBeanDefinition();
 	}
 

--- a/src/main/java/org/springframework/integration/kafka/dsl/Kafka.java
+++ b/src/main/java/org/springframework/integration/kafka/dsl/Kafka.java
@@ -38,6 +38,7 @@ import org.springframework.kafka.support.TopicPartitionOffset;
  * @author Artem Bilan
  * @author Nasko Vasilev
  * @author Gary Russell
+ * @author Anshul Mehra
  *
  * @since 3.0
  */
@@ -140,6 +141,78 @@ public final class Kafka {
 			String... topics) {
 
 		return new KafkaInboundChannelAdapterSpec<>(consumerFactory, ackCallbackFactory, allowMultiFetch, topics);
+	}
+
+	/**
+	 * Create an initial {@link KafkaInboundChannelAdapterSpec} with the consumer factory and
+	 * topic pattern.
+	 * @param consumerFactory the consumer factory.
+	 * @param topicPattern the topic pattern.
+	 * @param <K> the Kafka message key type.
+	 * @param <V> the Kafka message value type.
+	 * @return the spec.
+	 * @since 3.2.0
+	 */
+	public static <K, V> KafkaInboundChannelAdapterSpec<K, V> inboundChannelAdapter(
+			ConsumerFactory<K, V> consumerFactory, Pattern topicPattern) {
+
+		return inboundChannelAdapter(consumerFactory, false, topicPattern);
+	}
+
+	/**
+	 * Create an initial {@link KafkaInboundChannelAdapterSpec} with the consumer factory and
+	 * topic pattern.
+	 * @param consumerFactory the consumer factory.
+	 * @param allowMultiFetch true to fetch multiple records on each poll.
+	 * @param topicPattern the topic pattern.
+	 * @param <K> the Kafka message key type.
+	 * @param <V> the Kafka message value type.
+	 * @return the spec.
+	 * @since 3.2
+	 */
+	public static <K, V> KafkaInboundChannelAdapterSpec<K, V> inboundChannelAdapter(
+			ConsumerFactory<K, V> consumerFactory, boolean allowMultiFetch, Pattern topicPattern) {
+
+		return new KafkaInboundChannelAdapterSpec<>(consumerFactory, allowMultiFetch, topicPattern);
+	}
+
+	/**
+	 * Create an initial {@link KafkaInboundChannelAdapterSpec} with the consumer factory and
+	 * topic pattern with a custom ack callback factory.
+	 * @param consumerFactory the consumer factory.
+	 * @param ackCallbackFactory the callback factory.
+	 * @param topicPattern the topic pattern.
+	 * @param <K> the Kafka message key type.
+	 * @param <V> the Kafka message value type.
+	 * @return the spec.
+	 * @since 3.0.1
+	 */
+	public static <K, V> KafkaInboundChannelAdapterSpec<K, V> inboundChannelAdapter(
+			ConsumerFactory<K, V> consumerFactory,
+			KafkaAckCallbackFactory<K, V> ackCallbackFactory, Pattern topicPattern) {
+
+		return inboundChannelAdapter(consumerFactory, ackCallbackFactory, false, topicPattern);
+	}
+
+	/**
+	 * Create an initial {@link KafkaInboundChannelAdapterSpec} with the consumer factory and
+	 * topic pattern with a custom ack callback factory.
+	 * @param consumerFactory the consumer factory.
+	 * @param ackCallbackFactory the callback factory.
+	 * @param allowMultiFetch true to fetch multiple records on each poll.
+	 * @param topicPattern the topic pattern.
+	 * @param <K> the Kafka message key type.
+	 * @param <V> the Kafka message value type.
+	 * @return the spec.
+	 * @since 3.0.1
+	 */
+	public static <K, V> KafkaInboundChannelAdapterSpec<K, V> inboundChannelAdapter(
+			ConsumerFactory<K, V> consumerFactory,
+			KafkaAckCallbackFactory<K, V> ackCallbackFactory,
+			boolean allowMultiFetch,
+			Pattern topicPattern) {
+
+		return new KafkaInboundChannelAdapterSpec<>(consumerFactory, ackCallbackFactory, allowMultiFetch, topicPattern);
 	}
 
 	/**

--- a/src/main/java/org/springframework/integration/kafka/dsl/KafkaInboundChannelAdapterSpec.java
+++ b/src/main/java/org/springframework/integration/kafka/dsl/KafkaInboundChannelAdapterSpec.java
@@ -16,6 +16,8 @@
 
 package org.springframework.integration.kafka.dsl;
 
+import java.util.regex.Pattern;
+
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 
 import org.springframework.integration.dsl.MessageSourceSpec;
@@ -31,6 +33,7 @@ import org.springframework.kafka.support.converter.RecordMessageConverter;
  * @param <V> the value type.
  *
  * @author Gary Russell
+ * @author Anshul Mehra
  *
  * @since 3.0.1
  *
@@ -39,13 +42,31 @@ public class KafkaInboundChannelAdapterSpec<K, V>
 		extends MessageSourceSpec<KafkaInboundChannelAdapterSpec<K, V>, KafkaMessageSource<K, V>> {
 
 	KafkaInboundChannelAdapterSpec(ConsumerFactory<K, V> consumerFactory, boolean allowMultiFetch, String... topics) {
-		this.target = new KafkaMessageSource<>(consumerFactory, allowMultiFetch, topics);
+		KafkaMessageSource<K, V> source = new KafkaMessageSource<>(consumerFactory, allowMultiFetch);
+		source.setTopics(topics);
+		this.target = source;
 	}
 
 	KafkaInboundChannelAdapterSpec(ConsumerFactory<K, V> consumerFactory,
 			KafkaAckCallbackFactory<K, V> ackCallbackFactory, boolean allowMultiFetch, String... topics) {
 
-		this.target = new KafkaMessageSource<>(consumerFactory, ackCallbackFactory, allowMultiFetch, topics);
+		KafkaMessageSource<K, V> source = new KafkaMessageSource<>(consumerFactory, ackCallbackFactory, allowMultiFetch);
+		source.setTopics(topics);
+		this.target = source;
+	}
+
+	KafkaInboundChannelAdapterSpec(ConsumerFactory<K, V> consumerFactory, boolean allowMultiFetch, Pattern topicPattern) {
+		KafkaMessageSource<K, V> source = new KafkaMessageSource<>(consumerFactory, allowMultiFetch);
+		source.setTopicPattern(topicPattern);
+		this.target = source;
+	}
+
+	KafkaInboundChannelAdapterSpec(ConsumerFactory<K, V> consumerFactory,
+			KafkaAckCallbackFactory<K, V> ackCallbackFactory, boolean allowMultiFetch, Pattern topicPattern) {
+
+		KafkaMessageSource<K, V> source = new KafkaMessageSource<>(consumerFactory, ackCallbackFactory, allowMultiFetch);
+		source.setTopicPattern(topicPattern);
+		this.target = source;
 	}
 
 	public KafkaInboundChannelAdapterSpec<K, V> groupId(String groupId) {

--- a/src/main/resources/org/springframework/integration/kafka/config/spring-integration-kafka-3.2.xsd
+++ b/src/main/resources/org/springframework/integration/kafka/config/spring-integration-kafka-3.2.xsd
@@ -176,6 +176,18 @@
 					</xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>
+			<xsd:attribute name="topicPattern">
+				<xsd:annotation>
+					<xsd:documentation>
+						The topic pattern.
+					</xsd:documentation>
+					<xsd:appinfo>
+						<tool:annotation kind="ref">
+							<tool:expected-type type="java.util.regex.Pattern"/>
+						</tool:annotation>
+					</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:attribute>
 			<xsd:attribute name="group-id" use="required" type="xsd:string">
 				<xsd:annotation>
 					<xsd:documentation>

--- a/src/test/java/org/springframework/integration/kafka/inbound/MessageSourceIntegrationTests.java
+++ b/src/test/java/org/springframework/integration/kafka/inbound/MessageSourceIntegrationTests.java
@@ -59,7 +59,8 @@ public class MessageSourceIntegrationTests {
 		consumerProps.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 2);
 		consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
 		DefaultKafkaConsumerFactory<Integer, String> consumerFactory = new DefaultKafkaConsumerFactory<>(consumerProps);
-		KafkaMessageSource<Integer, String> source = new KafkaMessageSource<>(consumerFactory, TOPIC1);
+		KafkaMessageSource<Integer, String> source = new KafkaMessageSource<>(consumerFactory);
+		source.setTopics(TOPIC1);
 		final CountDownLatch assigned = new CountDownLatch(1);
 		source.setRebalanceListener(new ConsumerRebalanceListener() {
 


### PR DESCRIPTION
* Refactored to topics/topicPattern to be a property to
prevent constructor telescoping

resolves #280