### PR TITLE
Allow configuration of header-mapper in outbound-channel-adapter XML

### DIFF
--- a/src/main/java/org/springframework/integration/kafka/config/xml/KafkaParsingUtils.java
+++ b/src/main/java/org/springframework/integration/kafka/config/xml/KafkaParsingUtils.java
@@ -27,6 +27,7 @@ import org.springframework.integration.config.xml.IntegrationNamespaceUtils;
  * Utilities to assist with parsing XML.
  *
  * @author Gary Russell
+ * @author Tom van den Berge
  * @since 3.2
  *
  */

--- a/src/main/java/org/springframework/integration/kafka/config/xml/KafkaParsingUtils.java
+++ b/src/main/java/org/springframework/integration/kafka/config/xml/KafkaParsingUtils.java
@@ -81,6 +81,8 @@ public final class KafkaParsingUtils {
 		if (timestampExpressionDef != null) {
 			builder.addPropertyValue("timestampExpression", timestampExpressionDef);
 		}
+
+		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "header-mapper");
 	}
 
 }

--- a/src/main/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandler.java
+++ b/src/main/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandler.java
@@ -84,6 +84,7 @@ import org.springframework.util.concurrent.SettableListenableFuture;
  * @author Gary Russell
  * @author Marius Bogoevici
  * @author Biju Kunjummen
+ * @author Tom van den Berge
  *
  * @since 0.5
  */

--- a/src/main/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandler.java
+++ b/src/main/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandler.java
@@ -186,6 +186,10 @@ public class KafkaProducerMessageHandler<K, V> extends AbstractReplyProducingMes
 		this.headerMapper = headerMapper;
 	}
 
+	public KafkaHeaderMapper getHeaderMapper() {
+		return this.headerMapper;
+	}
+
 	public KafkaTemplate<?, ?> getKafkaTemplate() {
 		return this.kafkaTemplate;
 	}

--- a/src/main/resources/org/springframework/integration/kafka/config/spring-integration-kafka-3.2.xsd
+++ b/src/main/resources/org/springframework/integration/kafka/config/spring-integration-kafka-3.2.xsd
@@ -31,6 +31,7 @@
 				<xsd:extension base="outboundType">
 					<xsd:attributeGroup ref="integration:channelAdapterAttributes"/>
 					<xsd:attributeGroup ref="kafkaTemplate"/>
+					<xsd:attributeGroup ref="headerMapper"/>
 				</xsd:extension>
 			</xsd:complexContent>
 		</xsd:complexType>
@@ -126,6 +127,7 @@
 								]]></xsd:documentation>
 							</xsd:annotation>
 					</xsd:attribute>
+					<xsd:attributeGroup ref="headerMapper"/>
 				</xsd:extension>
 			</xsd:complexContent>
 		</xsd:complexType>
@@ -635,6 +637,21 @@
 				<xsd:appinfo>
 					<tool:annotation kind="ref">
 						<tool:expected-type type="org.springframework.kafka.core.KafkaTemplate" />
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
+	</xsd:attributeGroup>
+
+	<xsd:attributeGroup name="headerMapper">
+		<xsd:attribute name="header-mapper" use="optional" type="xsd:string">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
+							Specifies the HeaderMapper used map Spring message headers to or from Kafka message headers.
+				]]></xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.kafka.support.KafkaHeaderMapper" />
 					</tool:annotation>
 				</xsd:appinfo>
 			</xsd:annotation>

--- a/src/test/java/org/springframework/integration/kafka/config/xml/KafkaOutboundAdapterParserTests-context.xml
+++ b/src/test/java/org/springframework/integration/kafka/config/xml/KafkaOutboundAdapterParserTests-context.xml
@@ -23,6 +23,7 @@
 										error-message-strategy="ems"
 										send-failure-channel="failures"
 										send-success-channel="successes"
+										header-mapper="customHeaderMapper"
 	>
 		<int-kafka:request-handler-advice-chain>
 			<bean class="org.springframework.integration.handler.advice.RequestHandlerCircuitBreakerAdvice" />
@@ -53,5 +54,7 @@
 	<int:channel id="failures" />
 
 	<int:channel id="successes" />
+	
+	<bean id="customHeaderMapper" class="org.springframework.kafka.support.DefaultKafkaHeaderMapper" />
 
 </beans>

--- a/src/test/java/org/springframework/integration/kafka/config/xml/KafkaOutboundAdapterParserTests.java
+++ b/src/test/java/org/springframework/integration/kafka/config/xml/KafkaOutboundAdapterParserTests.java
@@ -53,6 +53,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  * @author Artem Bilan
  * @author Gary Russell
  * @author Biju Kunjummen
+ * @author Tom van den Berge
  *
  * @since 0.5
  */

--- a/src/test/java/org/springframework/integration/kafka/config/xml/KafkaOutboundAdapterParserTests.java
+++ b/src/test/java/org/springframework/integration/kafka/config/xml/KafkaOutboundAdapterParserTests.java
@@ -84,6 +84,8 @@ public class KafkaOutboundAdapterParserTests {
 				.isSameAs(this.appContext.getBean("failures"));
 		assertThat(TestUtils.getPropertyValue(messageHandler, "sendSuccessChannel"))
 				.isSameAs(this.appContext.getBean("successes"));
+		assertThat(TestUtils.getPropertyValue(messageHandler, "headerMapper"))
+				.isSameAs(this.appContext.getBean("customHeaderMapper"));
 
 		messageHandler
 				= this.appContext.getBean("kafkaOutboundChannelAdapter2.handler", KafkaProducerMessageHandler.class);
@@ -93,7 +95,6 @@ public class KafkaOutboundAdapterParserTests {
 
 		assertThat(TestUtils.getPropertyValue(messageHandler, "sendTimeoutExpression.literalValue")).isEqualTo("500");
 	}
-
 
 	@Test
 	public void testSyncMode() {

--- a/src/test/java/org/springframework/integration/kafka/config/xml/KafkaOutboundGatewayParserTests-context.xml
+++ b/src/test/java/org/springframework/integration/kafka/config/xml/KafkaOutboundGatewayParserTests-context.xml
@@ -23,7 +23,9 @@
 		send-timeout-expression="44"
 		sync="true"
 		timestamp-expression="T(System).currentTimeMillis()"
-		topic-expression="'topic'"/>
+		topic-expression="'topic'"
+		header-mapper="customHeaderMapper"
+		/>
 
 	<int:channel id="requests"/>
 
@@ -39,4 +41,5 @@
 		<constructor-arg value="org.springframework.kafka.requestreply.ReplyingKafkaTemplate"/>
 	</bean>
 
+	<bean id="customHeaderMapper" class="org.springframework.kafka.support.DefaultKafkaHeaderMapper" />
 </beans>

--- a/src/test/java/org/springframework/integration/kafka/config/xml/KafkaOutboundGatewayParserTests.java
+++ b/src/test/java/org/springframework/integration/kafka/config/xml/KafkaOutboundGatewayParserTests.java
@@ -66,6 +66,8 @@ public class KafkaOutboundGatewayParserTests {
 				.isSameAs(this.context.getBean("failures"));
 		assertThat(TestUtils.getPropertyValue(this.messageHandler, "sendSuccessChannel"))
 				.isSameAs(this.context.getBean("successes"));
+		assertThat(TestUtils.getPropertyValue(this.messageHandler, "headerMapper"))
+		.isSameAs(this.context.getBean("customHeaderMapper"));
 	}
 
 	public static class EMS extends DefaultErrorMessageStrategy {

--- a/src/test/java/org/springframework/integration/kafka/config/xml/KafkaOutboundGatewayParserTests.java
+++ b/src/test/java/org/springframework/integration/kafka/config/xml/KafkaOutboundGatewayParserTests.java
@@ -31,6 +31,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 /**
  * @author Gary Russell
+ * @author Tom van den Berge
  * @since 3.2
  *
  */
@@ -67,7 +68,7 @@ public class KafkaOutboundGatewayParserTests {
 		assertThat(TestUtils.getPropertyValue(this.messageHandler, "sendSuccessChannel"))
 				.isSameAs(this.context.getBean("successes"));
 		assertThat(TestUtils.getPropertyValue(this.messageHandler, "headerMapper"))
-		.isSameAs(this.context.getBean("customHeaderMapper"));
+				.isSameAs(this.context.getBean("customHeaderMapper"));
 	}
 
 	public static class EMS extends DefaultErrorMessageStrategy {

--- a/src/test/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandlerTests.java
+++ b/src/test/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandlerTests.java
@@ -104,6 +104,7 @@ import org.springframework.util.concurrent.SettableListenableFuture;
  * @author Gary Russell
  * @author Biju Kunjummen
  * @author Artem Bilan
+ * @author Tom van den Berge
  *
  * @since 2.0
  */
@@ -195,8 +196,6 @@ public class KafkaProducerMessageHandlerTests {
 		assertThat(record).has(key(2));
 		assertThat(record).has(partition(1));
 		assertThat(record.value()).isNull();
-
-		producerFactory.destroy();
 	}
 
 	@Test
@@ -347,6 +346,8 @@ public class KafkaProducerMessageHandlerTests {
 
 		ConsumerRecord<Integer, String> record = KafkaTestUtils.getSingleRecord(consumer, topic1);
 		assertThat(record.headers().toArray().length).isEqualTo(0);
+
+		producerFactory.destroy();
 	}
 
 	@Test

--- a/src/test/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandlerTests.java
+++ b/src/test/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandlerTests.java
@@ -196,7 +196,7 @@ public class KafkaProducerMessageHandlerTests {
 		assertThat(record).has(key(2));
 		assertThat(record).has(partition(1));
 		assertThat(record.value()).isNull();
-		
+
 		producerFactory.destroy();
 	}
 

--- a/src/test/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandlerTests.java
+++ b/src/test/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandlerTests.java
@@ -196,6 +196,8 @@ public class KafkaProducerMessageHandlerTests {
 		assertThat(record).has(key(2));
 		assertThat(record).has(partition(1));
 		assertThat(record.value()).isNull();
+		
+		producerFactory.destroy();
 	}
 
 	@Test


### PR DESCRIPTION
The XML configuration of an outbound-channel-adapter and outbound-gateway currently don't allow configuring a custom KafkaHeaderMapper. The KafkaProducerMessageHandler has a property for it, and it is already possible to set it using the DSL. It seems to be an omission in the XML configuration.

This pull request adds support for this.