### PR TITLE
Upgrade to SK 2.5.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,10 @@ ext {
 	log4jVersion = '2.13.0'
 	springIntegrationVersion = '5.3.0.BUILD-SNAPSHOT'
 	springIntegrationKotlinVersion = '0.0.3.BUILD-SNAPSHOT'
-	springKafkaVersion = '2.4.3.BUILD-SNAPSHOT'
+	springKafkaVersion = '2.5.0.BUILD-SNAPSHOT'
+
+	kafkaVersion = '2.4.1'
+	scalaVersion = '2.12'
 
 	idPrefix = 'kafka'
 
@@ -110,6 +113,9 @@ dependencies {
 	testCompile 'org.jetbrains.kotlin:kotlin-reflect'
 	testCompile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
 	testCompile 'org.junit.jupiter:junit-jupiter-api'
+
+	// temporary - gradle bug prevents getting this transitively
+	testCompile "org.apache.kafka:kafka_$scalaVersion:$kafkaVersion:test"
 
 	// To avoid compiler warnings about @API annotations in JUnit code
 	testCompileOnly 'org.apiguardian:apiguardian-api:1.0.0'

--- a/src/main/java/org/springframework/integration/kafka/dsl/Kafka.java
+++ b/src/main/java/org/springframework/integration/kafka/dsl/Kafka.java
@@ -16,7 +16,6 @@
 
 package org.springframework.integration.kafka.dsl;
 
-import java.util.Arrays;
 import java.util.regex.Pattern;
 
 import org.apache.kafka.common.TopicPartition;
@@ -294,26 +293,6 @@ public final class Kafka {
 	 * @param <K> the Kafka message key type.
 	 * @param <V> the Kafka message value type.
 	 * @return the KafkaMessageDrivenChannelAdapterSpec.KafkaMessageDrivenChannelAdapterListenerContainerSpec.
-	 * @deprecated in favor of {@link #messageDrivenChannelAdapter(ConsumerFactory, TopicPartitionOffset...)}.
-	 */
-	@Deprecated
-	public static <K, V>
-	KafkaMessageDrivenChannelAdapterSpec.KafkaMessageDrivenChannelAdapterListenerContainerSpec<K, V> messageDrivenChannelAdapter(
-			ConsumerFactory<K, V> consumerFactory,
-			org.springframework.kafka.support.TopicPartitionInitialOffset... topicPartitions) {
-
-		return messageDrivenChannelAdapter(consumerFactory, KafkaMessageDrivenChannelAdapter.ListenerMode.record,
-				topicPartitions);
-	}
-
-	/**
-	 * Create an initial
-	 * {@link KafkaMessageDrivenChannelAdapterSpec.KafkaMessageDrivenChannelAdapterListenerContainerSpec}.
-	 * @param consumerFactory the {@link ConsumerFactory}.
-	 * @param topicPartitions the {@link TopicPartition} vararg.
-	 * @param <K> the Kafka message key type.
-	 * @param <V> the Kafka message value type.
-	 * @return the KafkaMessageDrivenChannelAdapterSpec.KafkaMessageDrivenChannelAdapterListenerContainerSpec.
 	 */
 	public static <K, V>
 	KafkaMessageDrivenChannelAdapterSpec.KafkaMessageDrivenChannelAdapterListenerContainerSpec<K, V> messageDrivenChannelAdapter(
@@ -322,33 +301,6 @@ public final class Kafka {
 
 		return messageDrivenChannelAdapter(consumerFactory, KafkaMessageDrivenChannelAdapter.ListenerMode.record,
 				topicPartitions);
-	}
-
-	/**
-	 * Create an initial
-	 * {@link KafkaMessageDrivenChannelAdapterSpec.KafkaMessageDrivenChannelAdapterListenerContainerSpec}.
-	 * @param consumerFactory the {@link ConsumerFactory}.
-	 * @param listenerMode the {@link KafkaMessageDrivenChannelAdapter.ListenerMode}.
-	 * @param topicPartitions the {@link TopicPartition} vararg.
-	 * @param <K> the Kafka message key type.
-	 * @param <V> the Kafka message value type.
-	 * @return the
-	 * KafkaMessageDrivenChannelAdapterSpec.KafkaMessageDrivenChannelAdapterListenerContainerSpec.
-	 * @deprecated in favor of
-	 * {@link #messageDrivenChannelAdapter(ConsumerFactory, org.springframework.integration.kafka.inbound.KafkaMessageDrivenChannelAdapter.ListenerMode, TopicPartitionOffset...)}
-	 */
-	@Deprecated
-	public static <K, V>
-	KafkaMessageDrivenChannelAdapterSpec.KafkaMessageDrivenChannelAdapterListenerContainerSpec<K, V> messageDrivenChannelAdapter(
-			ConsumerFactory<K, V> consumerFactory,
-			KafkaMessageDrivenChannelAdapter.ListenerMode listenerMode,
-			org.springframework.kafka.support.TopicPartitionInitialOffset... topicPartitions) {
-
-		return messageDrivenChannelAdapter(
-				new KafkaMessageListenerContainerSpec<>(consumerFactory,
-						Arrays.stream(topicPartitions)
-						.map(org.springframework.kafka.support.TopicPartitionInitialOffset::toTPO)
-						.toArray(TopicPartitionOffset[]::new)), listenerMode);
 	}
 
 	/**

--- a/src/main/java/org/springframework/integration/kafka/inbound/KafkaInboundGateway.java
+++ b/src/main/java/org/springframework/integration/kafka/inbound/KafkaInboundGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 the original author or authors.
+ * Copyright 2018-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.kafka.inbound;
 
+import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
@@ -23,6 +24,7 @@ import java.util.function.BiConsumer;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.header.Header;
 
 import org.springframework.core.AttributeAccessor;
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
@@ -85,6 +87,8 @@ public class KafkaInboundGateway<K, V, R> extends MessagingGatewaySupport implem
 	private BiConsumer<Map<TopicPartition, Long>, ConsumerSeekAware.ConsumerSeekCallback> onPartitionsAssignedSeekCallback;
 
 	private boolean bindSourceRecord;
+
+	private boolean containerDeliveryAttemptPresent;
 
 	/**
 	 * Construct an instance with the provided container.
@@ -178,6 +182,8 @@ public class KafkaInboundGateway<K, V, R> extends MessagingGatewaySupport implem
 			this.retryTemplate.registerListener(this.listener);
 		}
 		this.messageListenerContainer.getContainerProperties().setMessageListener(kafkaListener);
+		this.containerDeliveryAttemptPresent = this.messageListenerContainer.getContainerProperties()
+				.isDeliveryAttemptHeader();
 	}
 
 	@Override
@@ -295,6 +301,11 @@ public class KafkaInboundGateway<K, V, R> extends MessagingGatewaySupport implem
 							new AtomicInteger(((RetryContext) attributesHolder.get()).getRetryCount() + 1);
 					rawHeaders.put(IntegrationMessageHeaderAccessor.DELIVERY_ATTEMPT, deliveryAttempt);
 				}
+				else if (KafkaInboundGateway.this.containerDeliveryAttemptPresent) {
+					Header header = record.headers().lastHeader(KafkaHeaders.DELIVERY_ATTEMPT);
+					rawHeaders.put(IntegrationMessageHeaderAccessor.DELIVERY_ATTEMPT,
+							new AtomicInteger(ByteBuffer.wrap(header.value()).getInt()));
+				}
 				if (KafkaInboundGateway.this.bindSourceRecord) {
 					rawHeaders.put(IntegrationMessageHeaderAccessor.SOURCE_DATA, record);
 				}
@@ -305,6 +316,11 @@ public class KafkaInboundGateway<K, V, R> extends MessagingGatewaySupport implem
 					AtomicInteger deliveryAttempt =
 							new AtomicInteger(((RetryContext) attributesHolder.get()).getRetryCount() + 1);
 					builder.setHeader(IntegrationMessageHeaderAccessor.DELIVERY_ATTEMPT, deliveryAttempt);
+				}
+				else if (KafkaInboundGateway.this.containerDeliveryAttemptPresent) {
+					Header header = record.headers().lastHeader(KafkaHeaders.DELIVERY_ATTEMPT);
+					builder.setHeader(IntegrationMessageHeaderAccessor.DELIVERY_ATTEMPT,
+							new AtomicInteger(ByteBuffer.wrap(header.value()).getInt()));
 				}
 				if (KafkaInboundGateway.this.bindSourceRecord) {
 					builder.setHeader(IntegrationMessageHeaderAccessor.SOURCE_DATA, record);


### PR DESCRIPTION
- add deliveryAttempt header when retry is not configured
- temporary work around for gradle bug, jar with test classifier missing from CP