### PR TITLE
Improve GRADLE build Performance

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 version=3.3.2.BUILD-SNAPSHOT
 org.gradle.caching=true
+org.gradle.vfs.watch = true


### PR DESCRIPTION

[File system watching](https://blog.gradle.org/introducing-file-system-watching). Since Gradle 6.5, File system watching was introduced which can help to avoid unnecessary I/O. This feature is the default since 7.0. For an older version, we can enable this feature by setting `org.gradle.vfs.watch=true`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
